### PR TITLE
REVERT: removes q2-fondue from the shotgun distro

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -55,10 +55,6 @@ packages:
   repo: qiime2/q2-fmt
   distros: [fmt]
 
-- name: q2-fondue
-  repo: bokulich-lab/q2-fondue
-  distros: [shotgun]
-
 - name: q2-fragment-insertion
   repo: qiime2/q2-fragment-insertion
   distros: [amplicon]


### PR DESCRIPTION
Reverts qiime2/distributions#52

Full description with reasoning behind this [here](https://forum.qiime2.org/t/next-steps-on-shotgun-distro-prepare-q2-fondue/28625). Goal is to get fondue in the shotgun distro once the issues described in the forum post above are resolved.