### PR TITLE
PREP: adds vsearch and fondue to shotgun distro (take 2)

### DIFF
--- a/2024.2/shotgun/passed/seed-environment-conda.yml
+++ b/2024.2/shotgun/passed/seed-environment-conda.yml
@@ -24,6 +24,7 @@ dependencies:
 - q2-emperor=2023.11.0.dev0+2.g706f4c4
 - q2-feature-classifier=2023.11.0.dev0+2.g7f9f1c8
 - q2-feature-table=2023.11.0.dev0+8.g9f87ffb
+- q2-fondue=0.0.0
 - q2-longitudinal=2023.11.0.dev0+3.gd55ee50
 - q2-metadata=2023.11.0.dev0+1.g5ac3877
 - q2-moshpit=2023.11.0.dev0+29.g9c5e435
@@ -35,6 +36,7 @@ dependencies:
 - q2-taxa=2023.11.0.dev0+1.g1efb0b0
 - q2-types-genomics=2023.11.0.dev0+8.g3b993ed
 - q2-types=2023.11.0.dev0+2.g1827eab
+- q2-vsearch=2023.11.0.dev0
 - q2cli=2023.11.0.dev0+13.g246f054
 - q2templates=2023.11.0.dev0+1.gba531e6
 - qiime2=2023.11.0.dev0+16.gc95b12b


### PR DESCRIPTION
trying again after adding [this GHA](https://github.com/qiime2/distributions/commit/3e26717113834e4ffc3d3924bd19aff5315ada28) to free up disk space.