### PR TITLE
maint: update mac runner to include conda

### DIFF
--- a/.github/workflows/ci-distro-trial_1-build-generation.yaml
+++ b/.github/workflows/ci-distro-trial_1-build-generation.yaml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJSON(needs.configure_matrix.outputs.matrix)[inputs.matrix-index] }}
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/ci-distro-trial_2-build-metapackage.yaml
+++ b/.github/workflows/ci-distro-trial_2-build-metapackage.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: qiime2/action-library-packaging/clean-disk@beta

--- a/.github/workflows/ci-distro-trial_3-test-metapackage.yaml
+++ b/.github/workflows/ci-distro-trial_3-test-metapackage.yaml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJSON(needs.configure_matrix.outputs.matrix) }}
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - name: get environment path

--- a/.github/workflows/create-prepare-pr.yaml
+++ b/.github/workflows/create-prepare-pr.yaml
@@ -113,7 +113,7 @@ jobs:
         id: copy-env
         if: contains(${{ needs.await-workflow.outputs.gh-response }}, 'merged:true')
         run: |
-          cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-macos-latest-conda.yml' './latest/passed/'
+          cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-macos-12-conda.yml' './latest/passed/'
           cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-ubuntu-latest-conda.yml' './latest/passed/'
 
       - name: Open Pull Request to update latest env files

--- a/.github/workflows/lib-ci-dev.yaml
+++ b/.github/workflows/lib-ci-dev.yaml
@@ -74,12 +74,15 @@ jobs:
       epoch: ${{ needs.setup.outputs.active-epoch }}
       seed_env_path: ${{ needs.setup.outputs.active-epoch }}/${{ inputs.distro }}/staged/seed-environment-conda.yml
       env_prefix: ./test-env
-    steps:
-      - name: 'Install conda on mac runner'
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          brew update
-          brew install --cask miniconda
+    # TODO: decide if we want to go this route or keep the macos-12 runners -
+    # latest macos runners no longer include miniconda for some reason
+    # https://github.com/actions/runner-images/blob/macos-14-arm64/20240422.3/images/macos/macos-14-arm64-Readme.md
+    # steps:
+    #   - name: 'Install conda on mac runner'
+    #     if: ${{ runner.os == 'macOS' }}
+    #     run: |
+    #       brew update
+    #       brew install --cask miniconda
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/lib-ci-dev.yaml
+++ b/.github/workflows/lib-ci-dev.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
     runs-on: ${{ matrix.os }}
     env:
       plugin_path: ./repo
@@ -80,7 +80,7 @@ jobs:
         run: |
           brew update
           brew install --cask miniconda
-          
+
       - uses: actions/checkout@v3
         with:
           path: ${{ env.plugin_path }}


### PR DESCRIPTION
So since we are using the 'latest' versions for our osx and ubuntu runners, we are subject to weekly updates to each runner's included packages/etc. The latest osx runner image (reference [here](https://github.com/actions/runner-images/blob/macos-14-arm64/20240422.3/images/macos/macos-14-arm64-Readme.md)) no longer includes miniconda as an included package for some reason, which breaks any ci action where we're using conda (so basically all of them).

I've updated the osx runner to macos-12 because that's what we were using prior to this week's runner update (reference [here](https://github.com/actions/runner-images/blob/macOS-12/20240418.1/images/macos/macos-12-Readme.md)) but also included a commented out step in our ci-dev workflow to install conda within the runner (if we'd like to keep using the latest mac runners instead of pinning at macos-12).

I'm going to merge this so that ci-dev can run successfully for any open PRs - but leaving these details here for posterity, and we can re-assess what the best path forward is next week. cc @ebolyen 