### PR TITLE
DEP: remove q2-vizard from fmt distro

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -113,7 +113,7 @@ packages:
 
 - name: q2-vizard
   repo: qiime2/q2-vizard
-  distros: [fmt]
+  distros: []
 
 - name: q2-vsearch
   repo: qiime2/q2-vsearch

--- a/data.yaml
+++ b/data.yaml
@@ -111,9 +111,9 @@ packages:
   repo: qiime2/q2-types
   distros: [tiny, amplicon, metagenome, fmt]
 
-- name: q2-vizard
-  repo: qiime2/q2-vizard
-  distros: []
+# - name: q2-vizard
+#   repo: qiime2/q2-vizard
+#   distros: []
 
 - name: q2-vsearch
   repo: qiime2/q2-vsearch


### PR DESCRIPTION
This PR removed q2-vizard from the FMT distro because it is not needed. 