### PR TITLE
MAINT: remove stats from 2024.10 amplicon seed env

### DIFF
--- a/2024.10/amplicon/passed/qiime2-amplicon-macos-latest-conda.yml
+++ b/2024.10/amplicon/passed/qiime2-amplicon-macos-latest-conda.yml
@@ -86,7 +86,6 @@ dependencies:
 - cctools_osx-64=986
 - certifi=2024.6.2
 - cffi=1.16.0
-- chardet=5.2.0
 - charset-normalizer=3.3.2
 - clang=18.1.7
 - clang-18=18.1.7
@@ -104,7 +103,7 @@ dependencies:
 - contourpy=1.2.1
 - cryptography=42.0.8
 - curl=8.8.0
-- cutadapt=4.8
+- cutadapt=4.9
 - cycler=0.12.1
 - deblur=1.1.1
 - debugpy=1.8.1
@@ -121,7 +120,7 @@ dependencies:
 - expat=2.6.2
 - fastcluster=1.2.6
 - fasttree=2.1.11
-- filelock=3.15.1
+- filelock=3.15.4
 - flufl.lock=7.1
 - font-ttf-dejavu-sans-mono=2.37
 - font-ttf-inconsolata=3.000
@@ -135,7 +134,6 @@ dependencies:
 - fqdn=1.5.1
 - freetype=2.12.1
 - fribidi=1.0.10
-- frictionless=5.5.0
 - future=1.0.0
 - gawk=5.3.0
 - gettext=0.22.5
@@ -155,13 +153,12 @@ dependencies:
 - hdmedians=0.14.2
 - hmmer=3.1b2
 - htslib=1.20
-- humanize=4.9.0
 - icu=73.2
 - idna=3.7
 - ijson=3.3.0
-- importlib-metadata=7.1.0
+- importlib-metadata=7.2.1
 - importlib-resources=6.4.0
-- importlib_metadata=7.1.0
+- importlib_metadata=7.2.1
 - importlib_resources=6.4.0
 - iniconfig=2.0.0
 - interface_meta=1.3.0
@@ -173,7 +170,6 @@ dependencies:
 - iqtree=2.3.4
 - isa-l=2.31.0
 - isl=0.26
-- isodate=0.6.1
 - isoduration=20.11.0
 - jedi=0.19.1
 - jinja2=3.1.4
@@ -242,7 +238,7 @@ dependencies:
 - libxml2=2.12.7
 - libxslt=1.1.39
 - libzlib=1.2.13
-- llvm-openmp=18.1.7
+- llvm-openmp=18.1.8
 - llvm-tools=18.1.7
 - llvmlite=0.42.0
 - lxml=5.2.2
@@ -250,13 +246,10 @@ dependencies:
 - lz4-c=1.9.4
 - mafft=7.520
 - make=4.3
-- markdown-it-py=3.0.0
-- marko=2.1.0
 - markupsafe=2.1.5
 - matplotlib=3.8.4
 - matplotlib-base=3.8.4
 - matplotlib-inline=0.1.7
-- mdurl=0.1.2
 - mistune=3.0.2
 - mpc=1.3.1
 - mpfr=4.2.1
@@ -315,7 +308,6 @@ dependencies:
 - perl-scalar-list-utils=1.63
 - perl-storable=3.15
 - perl-types-serialiser=1.01
-- petl=1.7.15
 - pexpect=4.9.0
 - pickleshare=0.7.5
 - pigz=2.8
@@ -348,7 +340,6 @@ dependencies:
 - python-fastjsonschema=2.20.0
 - python-isal=1.6.1
 - python-json-logger=2.0.7
-- python-slugify=8.0.4
 - python-tzdata=2024.1
 - python-zlib-ng=0.4.3
 - python_abi=3.9
@@ -362,7 +353,7 @@ dependencies:
 - q2-dada2=2024.10.0.dev0
 - q2-deblur=2024.10.0.dev0
 - q2-demux=2024.10.0.dev0
-- q2-diversity=2024.10.0.dev0
+- q2-diversity=2024.10.0.dev0+1.g368a9eb
 - q2-diversity-lib=2024.10.0.dev0
 - q2-emperor=2024.10.0.dev0
 - q2-feature-classifier=2024.10.0.dev0
@@ -375,7 +366,6 @@ dependencies:
 - q2-quality-control=2024.10.0.dev0
 - q2-quality-filter=2024.10.0.dev0
 - q2-sample-classifier=2024.10.0.dev0
-- q2-stats=2024.10.0.dev0+1.g6711b86
 - q2-taxa=2024.10.0.dev0
 - q2-types=2024.10.0.dev0
 - q2-vsearch=2024.10.0.dev0
@@ -407,14 +397,14 @@ dependencies:
 - r-cellranger=1.1.0
 - r-checkmate=2.3.1
 - r-class=7.3_22
-- r-cli=3.6.2
+- r-cli=3.6.3
 - r-clipr=0.8.0
 - r-cluster=2.1.6
 - r-codetools=0.2_20
 - r-colorspace=2.1_0
 - r-conflicted=1.2.0
 - r-cpp11=0.4.7
-- r-crayon=1.5.2
+- r-crayon=1.5.3
 - r-curl=5.1.0
 - r-cvxr=1.0_13
 - r-data.table=1.15.2
@@ -422,7 +412,7 @@ dependencies:
 - r-dbplyr=2.5.0
 - r-deldir=2.0_4
 - r-desctools=0.99.54
-- r-digest=0.6.35
+- r-digest=0.6.36
 - r-doparallel=1.0.17
 - r-dorng=1.8.6
 - r-dplyr=1.1.4
@@ -608,11 +598,9 @@ dependencies:
 - readline=8.2
 - referencing=0.35.1
 - requests=2.32.3
-- rescript=2024.10.0.dev0+7.g3c179ca
+- rescript=2024.10.0.dev0+8.g7d9ef27
 - rfc3339-validator=0.1.4
-- rfc3986=2.0.0
 - rfc3986-validator=0.1.1
-- rich=13.7.1
 - rpds-py=0.18.1
 - samtools=1.20
 - scikit-bio=0.6.0
@@ -623,10 +611,8 @@ dependencies:
 - send2trash=1.8.3
 - sepp=4.4.0
 - setproctitle=1.3.3
-- setuptools=70.0.0
-- shellingham=1.5.4
+- setuptools=70.1.0
 - sigtool=0.1.3
-- simpleeval=0.9.13
 - simplejson=3.19.2
 - six=1.16.0
 - sniffio=1.3.1
@@ -634,13 +620,10 @@ dependencies:
 - soupsieve=2.5
 - stack_data=0.6.2
 - statsmodels=0.14.2
-- stringcase=1.2.0
-- tabulate=0.9.0
 - tapi=1100.0.11
 - tbb=2021.12.0
 - tblib=3.0.0
 - terminado=0.18.1
-- text-unidecode=1.3
 - threadpoolctl=3.5.0
 - tinycss2=1.3.0
 - tk=8.6.13
@@ -653,9 +636,6 @@ dependencies:
 - tqdm=4.66.4
 - traitlets=5.9.0
 - typeguard=4.3.0
-- typer=0.12.3
-- typer-slim=0.12.3
-- typer-slim-standard=0.12.3
 - types-python-dateutil=2.9.0.20240316
 - typing-extensions=4.12.2
 - typing_extensions=4.12.2
@@ -668,7 +648,6 @@ dependencies:
 - unifrac-binaries=1.4
 - uri-template=1.3.0
 - urllib3=1.26.19
-- validators=0.28.3
 - vsearch=2.22.1
 - wcwidth=0.2.13
 - webcolors=24.6.0
@@ -688,6 +667,6 @@ dependencies:
 - zeromq=4.3.5
 - zipp=3.19.2
 - zlib=1.2.13
-- zlib-ng=2.0.7
-- zstandard=0.19.0
+- zlib-ng=2.2.0
+- zstandard=0.22.0
 - zstd=1.5.6

--- a/2024.10/amplicon/passed/qiime2-amplicon-ubuntu-latest-conda.yml
+++ b/2024.10/amplicon/passed/qiime2-amplicon-ubuntu-latest-conda.yml
@@ -89,7 +89,6 @@ dependencies:
 - cairo=1.18.0
 - certifi=2024.6.2
 - cffi=1.16.0
-- chardet=5.2.0
 - charset-normalizer=3.3.2
 - click=8.1.7
 - colorama=0.4.6
@@ -98,7 +97,7 @@ dependencies:
 - contourpy=1.2.1
 - cryptography=42.0.8
 - curl=8.8.0
-- cutadapt=4.8
+- cutadapt=4.9
 - cycler=0.12.1
 - dbus=1.13.6
 - deblur=1.1.1
@@ -116,7 +115,7 @@ dependencies:
 - expat=2.6.2
 - fastcluster=1.2.6
 - fasttree=2.1.11
-- filelock=3.15.1
+- filelock=3.15.4
 - flufl.lock=7.1
 - font-ttf-dejavu-sans-mono=2.37
 - font-ttf-inconsolata=3.000
@@ -130,7 +129,6 @@ dependencies:
 - fqdn=1.5.1
 - freetype=2.12.1
 - fribidi=1.0.10
-- frictionless=5.5.0
 - future=1.0.0
 - gawk=5.3.0
 - gcc_impl_linux-64=13.2.0
@@ -156,13 +154,12 @@ dependencies:
 - hdmedians=0.14.2
 - hmmer=3.1b2
 - htslib=1.20
-- humanize=4.9.0
 - icu=73.2
 - idna=3.7
 - ijson=3.3.0
-- importlib-metadata=7.1.0
+- importlib-metadata=7.2.1
 - importlib-resources=6.4.0
-- importlib_metadata=7.1.0
+- importlib_metadata=7.2.1
 - importlib_resources=6.4.0
 - iniconfig=2.0.0
 - interface_meta=1.3.0
@@ -173,7 +170,6 @@ dependencies:
 - ipywidgets=8.1.3
 - iqtree=2.3.4
 - isa-l=2.31.0
-- isodate=0.6.1
 - isoduration=20.11.0
 - jedi=0.19.1
 - jinja2=3.1.4
@@ -271,13 +267,10 @@ dependencies:
 - lz4-c=1.9.4
 - mafft=7.520
 - make=4.3
-- markdown-it-py=3.0.0
-- marko=2.1.0
 - markupsafe=2.1.5
 - matplotlib=3.8.4
 - matplotlib-base=3.8.4
 - matplotlib-inline=0.1.7
-- mdurl=0.1.2
 - mistune=3.0.2
 - mpfr=4.2.1
 - mpg123=1.32.6
@@ -340,7 +333,6 @@ dependencies:
 - perl-scalar-list-utils=1.63
 - perl-storable=3.15
 - perl-types-serialiser=1.01
-- petl=1.7.15
 - pexpect=4.9.0
 - pickleshare=0.7.5
 - pigz=2.8
@@ -375,7 +367,6 @@ dependencies:
 - python-fastjsonschema=2.20.0
 - python-isal=1.6.1
 - python-json-logger=2.0.7
-- python-slugify=8.0.4
 - python-tzdata=2024.1
 - python-zlib-ng=0.4.3
 - python_abi=3.9
@@ -389,7 +380,7 @@ dependencies:
 - q2-dada2=2024.10.0.dev0
 - q2-deblur=2024.10.0.dev0
 - q2-demux=2024.10.0.dev0
-- q2-diversity=2024.10.0.dev0
+- q2-diversity=2024.10.0.dev0+1.g368a9eb
 - q2-diversity-lib=2024.10.0.dev0
 - q2-emperor=2024.10.0.dev0
 - q2-feature-classifier=2024.10.0.dev0
@@ -402,7 +393,6 @@ dependencies:
 - q2-quality-control=2024.10.0.dev0
 - q2-quality-filter=2024.10.0.dev0
 - q2-sample-classifier=2024.10.0.dev0
-- q2-stats=2024.10.0.dev0+1.g6711b86
 - q2-taxa=2024.10.0.dev0
 - q2-types=2024.10.0.dev0
 - q2-vsearch=2024.10.0.dev0
@@ -435,14 +425,14 @@ dependencies:
 - r-cellranger=1.1.0
 - r-checkmate=2.3.1
 - r-class=7.3_22
-- r-cli=3.6.2
+- r-cli=3.6.3
 - r-clipr=0.8.0
 - r-cluster=2.1.6
 - r-codetools=0.2_20
 - r-colorspace=2.1_0
 - r-conflicted=1.2.0
 - r-cpp11=0.4.7
-- r-crayon=1.5.2
+- r-crayon=1.5.3
 - r-curl=5.1.0
 - r-cvxr=1.0_13
 - r-data.table=1.15.2
@@ -450,7 +440,7 @@ dependencies:
 - r-dbplyr=2.5.0
 - r-deldir=2.0_4
 - r-desctools=0.99.54
-- r-digest=0.6.35
+- r-digest=0.6.36
 - r-doparallel=1.0.17
 - r-dorng=1.8.6
 - r-dplyr=1.1.4
@@ -636,11 +626,9 @@ dependencies:
 - readline=8.2
 - referencing=0.35.1
 - requests=2.32.3
-- rescript=2024.10.0.dev0+7.g3c179ca
+- rescript=2024.10.0.dev0+8.g7d9ef27
 - rfc3339-validator=0.1.4
-- rfc3986=2.0.0
 - rfc3986-validator=0.1.1
-- rich=13.7.1
 - rpds-py=0.18.1
 - samtools=1.20
 - scikit-bio=0.6.0
@@ -652,9 +640,7 @@ dependencies:
 - send2trash=1.8.3
 - sepp=4.4.0
 - setproctitle=1.3.3
-- setuptools=70.0.0
-- shellingham=1.5.4
-- simpleeval=0.9.13
+- setuptools=70.1.0
 - simplejson=3.19.2
 - sip=6.7.12
 - six=1.16.0
@@ -663,14 +649,11 @@ dependencies:
 - soupsieve=2.5
 - stack_data=0.6.2
 - statsmodels=0.14.2
-- stringcase=1.2.0
 - sysroot_linux-64=2.12
-- tabulate=0.9.0
 - tapi=1100.0.11
 - tbb=2021.12.0
 - tblib=3.0.0
 - terminado=0.18.1
-- text-unidecode=1.3
 - threadpoolctl=3.5.0
 - tinycss2=1.3.0
 - tk=8.6.13
@@ -683,9 +666,6 @@ dependencies:
 - tqdm=4.66.4
 - traitlets=5.9.0
 - typeguard=4.3.0
-- typer=0.12.3
-- typer-slim=0.12.3
-- typer-slim-standard=0.12.3
 - types-python-dateutil=2.9.0.20240316
 - typing-extensions=4.12.2
 - typing_extensions=4.12.2
@@ -698,7 +678,6 @@ dependencies:
 - unifrac-binaries=1.4
 - uri-template=1.3.0
 - urllib3=1.26.19
-- validators=0.28.3
 - vsearch=2.22.1
 - wcwidth=0.2.13
 - webcolors=24.6.0
@@ -741,6 +720,6 @@ dependencies:
 - zeromq=4.3.5
 - zipp=3.19.2
 - zlib=1.2.13
-- zlib-ng=2.0.7
-- zstandard=0.19.0
+- zlib-ng=2.2.0
+- zstandard=0.22.0
 - zstd=1.5.6

--- a/2024.10/amplicon/passed/seed-environment-conda.yml
+++ b/2024.10/amplicon/passed/seed-environment-conda.yml
@@ -24,7 +24,7 @@ dependencies:
 - q2-deblur=2024.10.0.dev0
 - q2-demux=2024.10.0.dev0
 - q2-diversity-lib=2024.10.0.dev0
-- q2-diversity=2024.10.0.dev0
+- q2-diversity=2024.10.0.dev0+1.g368a9eb
 - q2-emperor=2024.10.0.dev0
 - q2-feature-classifier=2024.10.0.dev0
 - q2-feature-table=2024.10.0.dev0+1.gd9e5678
@@ -45,7 +45,7 @@ dependencies:
 - qiime2=2024.10.0.dev0
 - r-base=4.3.3
 - r-reticulate=1.36.0
-- rescript=2024.10.0.dev0+7.g3c179ca
+- rescript=2024.10.0.dev0+8.g7d9ef27
 - scikit-bio=0.6.0
 - scikit-learn=1.4.2
 - scipy=1.13.0

--- a/2024.10/amplicon/passed/seed-environment-conda.yml
+++ b/2024.10/amplicon/passed/seed-environment-conda.yml
@@ -36,7 +36,6 @@ dependencies:
 - q2-quality-control=2024.10.0.dev0
 - q2-quality-filter=2024.10.0.dev0
 - q2-sample-classifier=2024.10.0.dev0
-- q2-stats=2024.10.0.dev0+1.g6711b86
 - q2-taxa=2024.10.0.dev0
 - q2-types=2024.10.0.dev0
 - q2-vsearch=2024.10.0.dev0

--- a/2024.10/amplicon/staged/seed-environment-conda.yml
+++ b/2024.10/amplicon/staged/seed-environment-conda.yml
@@ -24,7 +24,7 @@ dependencies:
 - q2-deblur=2024.10.0.dev0
 - q2-demux=2024.10.0.dev0
 - q2-diversity-lib=2024.10.0.dev0
-- q2-diversity=2024.10.0.dev0
+- q2-diversity=2024.10.0.dev0+1.g368a9eb
 - q2-emperor=2024.10.0.dev0
 - q2-feature-classifier=2024.10.0.dev0
 - q2-feature-table=2024.10.0.dev0+1.gd9e5678
@@ -45,7 +45,7 @@ dependencies:
 - qiime2=2024.10.0.dev0
 - r-base=4.3.3
 - r-reticulate=1.36.0
-- rescript=2024.10.0.dev0+7.g3c179ca
+- rescript=2024.10.0.dev0+8.g7d9ef27
 - scikit-bio=0.6.0
 - scikit-learn=1.4.2
 - scipy=1.13.0

--- a/2024.10/amplicon/staged/seed-environment-conda.yml
+++ b/2024.10/amplicon/staged/seed-environment-conda.yml
@@ -36,7 +36,6 @@ dependencies:
 - q2-quality-control=2024.10.0.dev0
 - q2-quality-filter=2024.10.0.dev0
 - q2-sample-classifier=2024.10.0.dev0
-- q2-stats=2024.10.0.dev0+1.g6711b86
 - q2-taxa=2024.10.0.dev0
 - q2-types=2024.10.0.dev0
 - q2-vsearch=2024.10.0.dev0


### PR DESCRIPTION
@ebolyen I'm just going to remove this for now and we can put it back in when you're ready to test it against the distro (just in case we have to patch again... knock on wood)