### PR TITLE
DISTRO: add pathogenome

### DIFF
--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -24,3 +24,10 @@ jobs:
     secrets: inherit
     with:
       distro: metagenome
+
+  pathogenome:
+    needs: [metagenome]
+    uses: ./.github/workflows/create-prepare-pr.yaml
+    secrets: inherit
+    with:
+      distro: pathogenome


### PR DESCRIPTION
this adds the pathogenome distro to the cron-prepare workflow, which will trigger `create-prepare-pr` for the pathogenome distro after metagenome has completed.