### PR TITLE
REL: 2024.10 (tiny) take 2

### DIFF
--- a/2024.10/tiny/passed/qiime2-tiny-macos-latest-conda.yml
+++ b/2024.10/tiny/passed/qiime2-tiny-macos-latest-conda.yml
@@ -182,7 +182,7 @@ dependencies:
 - pluggy=1.5.0
 - prometheus_client=0.21.0
 - prompt-toolkit=3.0.48
-- psutil=6.0.0
+- psutil=6.1.0
 - ptyprocess=0.7.0
 - pure_eval=0.2.3
 - pycparser=2.22
@@ -207,9 +207,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-here=1.0.1
 - r-jsonlite=1.8.9
@@ -245,7 +245,7 @@ dependencies:
 - tblib=3.0.0
 - terminado=0.18.1
 - threadpoolctl=3.5.0
-- tinycss2=1.3.0
+- tinycss2=1.4.0
 - tk=8.6.13
 - tktable=2.10
 - tomli=2.0.2

--- a/2024.10/tiny/passed/qiime2-tiny-ubuntu-latest-conda.yml
+++ b/2024.10/tiny/passed/qiime2-tiny-ubuntu-latest-conda.yml
@@ -177,7 +177,7 @@ dependencies:
 - pluggy=1.5.0
 - prometheus_client=0.21.0
 - prompt-toolkit=3.0.48
-- psutil=6.0.0
+- psutil=6.1.0
 - pthread-stubs=0.4
 - ptyprocess=0.7.0
 - pure_eval=0.2.3
@@ -201,9 +201,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-here=1.0.1
 - r-jsonlite=1.8.9
@@ -239,7 +239,7 @@ dependencies:
 - tblib=3.0.0
 - terminado=0.18.1
 - threadpoolctl=3.5.0
-- tinycss2=1.3.0
+- tinycss2=1.4.0
 - tk=8.6.13
 - tktable=2.10
 - tomli=2.0.2

--- a/2024.10/tiny/passed/seed-environment-conda.yml
+++ b/2024.10/tiny/passed/seed-environment-conda.yml
@@ -14,9 +14,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-reticulate=1.36.0
 - scikit-bio=0.6.0

--- a/2024.10/tiny/released/qiime2-tiny-macos-latest-conda.yml
+++ b/2024.10/tiny/released/qiime2-tiny-macos-latest-conda.yml
@@ -182,7 +182,7 @@ dependencies:
 - pluggy=1.5.0
 - prometheus_client=0.21.0
 - prompt-toolkit=3.0.48
-- psutil=6.0.0
+- psutil=6.1.0
 - ptyprocess=0.7.0
 - pure_eval=0.2.3
 - pycparser=2.22
@@ -207,9 +207,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-here=1.0.1
 - r-jsonlite=1.8.9
@@ -245,7 +245,7 @@ dependencies:
 - tblib=3.0.0
 - terminado=0.18.1
 - threadpoolctl=3.5.0
-- tinycss2=1.3.0
+- tinycss2=1.4.0
 - tk=8.6.13
 - tktable=2.10
 - tomli=2.0.2

--- a/2024.10/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
+++ b/2024.10/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
@@ -177,7 +177,7 @@ dependencies:
 - pluggy=1.5.0
 - prometheus_client=0.21.0
 - prompt-toolkit=3.0.48
-- psutil=6.0.0
+- psutil=6.1.0
 - pthread-stubs=0.4
 - ptyprocess=0.7.0
 - pure_eval=0.2.3
@@ -201,9 +201,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-here=1.0.1
 - r-jsonlite=1.8.9
@@ -239,7 +239,7 @@ dependencies:
 - tblib=3.0.0
 - terminado=0.18.1
 - threadpoolctl=3.5.0
-- tinycss2=1.3.0
+- tinycss2=1.4.0
 - tk=8.6.13
 - tktable=2.10
 - tomli=2.0.2

--- a/2024.10/tiny/released/seed-environment-conda.yml
+++ b/2024.10/tiny/released/seed-environment-conda.yml
@@ -1,4 +1,3 @@
-# release take 2
 channels:
 - https://packages.qiime2.org/qiime2/2024.10/tiny/released
 - conda-forge
@@ -15,9 +14,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-reticulate=1.36.0
 - scikit-bio=0.6.0

--- a/2024.10/tiny/released/seed-environment-conda.yml
+++ b/2024.10/tiny/released/seed-environment-conda.yml
@@ -1,3 +1,4 @@
+# release take 2
 channels:
 - https://packages.qiime2.org/qiime2/2024.10/tiny/released
 - conda-forge

--- a/2024.10/tiny/staged/seed-environment-conda.yml
+++ b/2024.10/tiny/staged/seed-environment-conda.yml
@@ -15,9 +15,9 @@ dependencies:
 - q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-types=2024.10.0
-- q2cli=2024.10.0
+- q2cli=2024.10.1
 - q2templates=2024.10.0
-- qiime2=2024.10.0
+- qiime2=2024.10.1
 - r-base=4.3.3
 - r-reticulate=1.36.0
 - scikit-bio=0.6.0


### PR DESCRIPTION
(same reason for re-run as amplicon) re-releasing with framework/cli patch: https://github.com/qiime2/qiime2/pull/807