### PR TITLE
REL: 2024.10 (pathogenome) take 3

### DIFF
--- a/2024.10/pathogenome/passed/qiime2-pathogenome-macos-latest-conda.yml
+++ b/2024.10/pathogenome/passed/qiime2-pathogenome-macos-latest-conda.yml
@@ -317,7 +317,7 @@ dependencies:
 - pexpect=4.9.0
 - pickleshare=0.7.5
 - pillow=10.3.0
-- pip=24.2
+- pip=24.3.1
 - pixman=0.43.4
 - pkgutil-resolve-name=1.3.10
 - platformdirs=4.3.6
@@ -359,6 +359,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0
@@ -453,7 +454,7 @@ dependencies:
 - r-openssl=2.2.2
 - r-optparse=1.7.5
 - r-pillar=1.9.0
-- r-pkgbuild=1.4.4
+- r-pkgbuild=1.4.5
 - r-pkgconfig=2.0.3
 - r-pkgload=1.4.0
 - r-plogr=0.2.0
@@ -463,7 +464,7 @@ dependencies:
 - r-prettyunits=1.2.0
 - r-processx=3.8.4
 - r-progress=1.2.3
-- r-ps=1.8.0
+- r-ps=1.8.1
 - r-purrr=1.0.2
 - r-r6=2.5.1
 - r-ragg=1.3.3
@@ -511,7 +512,7 @@ dependencies:
 - r-viridislite=0.4.2
 - r-vroom=1.6.5
 - r-waldo=0.5.3
-- r-withr=3.0.1
+- r-withr=3.0.2
 - r-xfun=0.48
 - r-xml=3.99_0.17
 - r-xml2=1.3.6
@@ -557,7 +558,7 @@ dependencies:
 - tomlkit=0.13.2
 - tornado=6.4.1
 - traitlets=5.9.0
-- typeguard=4.3.0
+- typeguard=4.4.0
 - types-python-dateutil=2.9.0.20241003
 - typing-extensions=4.12.2
 - typing_extensions=4.12.2

--- a/2024.10/pathogenome/passed/qiime2-pathogenome-ubuntu-latest-conda.yml
+++ b/2024.10/pathogenome/passed/qiime2-pathogenome-ubuntu-latest-conda.yml
@@ -255,7 +255,7 @@ dependencies:
 - megahit=1.2.9
 - minimap2=2.28
 - mistune=3.0.2
-- mpg123=1.32.6
+- mpg123=1.32.8
 - mpi=1.0.1
 - munkres=1.1.4
 - mysql-common=8.3.0
@@ -348,7 +348,7 @@ dependencies:
 - pexpect=4.9.0
 - pickleshare=0.7.5
 - pillow=10.3.0
-- pip=24.2
+- pip=24.3.1
 - pixman=0.43.2
 - pkgutil-resolve-name=1.3.10
 - platformdirs=4.3.6
@@ -392,6 +392,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0
@@ -487,7 +488,7 @@ dependencies:
 - r-openssl=2.2.2
 - r-optparse=1.7.5
 - r-pillar=1.9.0
-- r-pkgbuild=1.4.4
+- r-pkgbuild=1.4.5
 - r-pkgconfig=2.0.3
 - r-pkgload=1.4.0
 - r-plogr=0.2.0
@@ -497,7 +498,7 @@ dependencies:
 - r-prettyunits=1.2.0
 - r-processx=3.8.4
 - r-progress=1.2.3
-- r-ps=1.8.0
+- r-ps=1.8.1
 - r-purrr=1.0.2
 - r-r6=2.5.1
 - r-ragg=1.3.3
@@ -545,7 +546,7 @@ dependencies:
 - r-viridislite=0.4.2
 - r-vroom=1.6.5
 - r-waldo=0.5.3
-- r-withr=3.0.1
+- r-withr=3.0.2
 - r-xfun=0.48
 - r-xml=3.99_0.17
 - r-xml2=1.3.6
@@ -595,7 +596,7 @@ dependencies:
 - tornado=6.4.1
 - traitlets=5.9.0
 - trf=4.09.1
-- typeguard=4.3.0
+- typeguard=4.4.0
 - types-python-dateutil=2.9.0.20241003
 - typing-extensions=4.12.2
 - typing_extensions=4.12.2

--- a/2024.10/pathogenome/passed/seed-environment-conda.yml
+++ b/2024.10/pathogenome/passed/seed-environment-conda.yml
@@ -21,6 +21,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0

--- a/2024.10/pathogenome/released/qiime2-pathogenome-macos-latest-conda.yml
+++ b/2024.10/pathogenome/released/qiime2-pathogenome-macos-latest-conda.yml
@@ -317,7 +317,7 @@ dependencies:
 - pexpect=4.9.0
 - pickleshare=0.7.5
 - pillow=10.3.0
-- pip=24.2
+- pip=24.3.1
 - pixman=0.43.4
 - pkgutil-resolve-name=1.3.10
 - platformdirs=4.3.6
@@ -359,6 +359,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0
@@ -453,7 +454,7 @@ dependencies:
 - r-openssl=2.2.2
 - r-optparse=1.7.5
 - r-pillar=1.9.0
-- r-pkgbuild=1.4.4
+- r-pkgbuild=1.4.5
 - r-pkgconfig=2.0.3
 - r-pkgload=1.4.0
 - r-plogr=0.2.0
@@ -463,7 +464,7 @@ dependencies:
 - r-prettyunits=1.2.0
 - r-processx=3.8.4
 - r-progress=1.2.3
-- r-ps=1.8.0
+- r-ps=1.8.1
 - r-purrr=1.0.2
 - r-r6=2.5.1
 - r-ragg=1.3.3
@@ -511,7 +512,7 @@ dependencies:
 - r-viridislite=0.4.2
 - r-vroom=1.6.5
 - r-waldo=0.5.3
-- r-withr=3.0.1
+- r-withr=3.0.2
 - r-xfun=0.48
 - r-xml=3.99_0.17
 - r-xml2=1.3.6
@@ -557,7 +558,7 @@ dependencies:
 - tomlkit=0.13.2
 - tornado=6.4.1
 - traitlets=5.9.0
-- typeguard=4.3.0
+- typeguard=4.4.0
 - types-python-dateutil=2.9.0.20241003
 - typing-extensions=4.12.2
 - typing_extensions=4.12.2

--- a/2024.10/pathogenome/released/qiime2-pathogenome-ubuntu-latest-conda.yml
+++ b/2024.10/pathogenome/released/qiime2-pathogenome-ubuntu-latest-conda.yml
@@ -255,7 +255,7 @@ dependencies:
 - megahit=1.2.9
 - minimap2=2.28
 - mistune=3.0.2
-- mpg123=1.32.6
+- mpg123=1.32.8
 - mpi=1.0.1
 - munkres=1.1.4
 - mysql-common=8.3.0
@@ -348,7 +348,7 @@ dependencies:
 - pexpect=4.9.0
 - pickleshare=0.7.5
 - pillow=10.3.0
-- pip=24.2
+- pip=24.3.1
 - pixman=0.43.2
 - pkgutil-resolve-name=1.3.10
 - platformdirs=4.3.6
@@ -392,6 +392,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0
@@ -487,7 +488,7 @@ dependencies:
 - r-openssl=2.2.2
 - r-optparse=1.7.5
 - r-pillar=1.9.0
-- r-pkgbuild=1.4.4
+- r-pkgbuild=1.4.5
 - r-pkgconfig=2.0.3
 - r-pkgload=1.4.0
 - r-plogr=0.2.0
@@ -497,7 +498,7 @@ dependencies:
 - r-prettyunits=1.2.0
 - r-processx=3.8.4
 - r-progress=1.2.3
-- r-ps=1.8.0
+- r-ps=1.8.1
 - r-purrr=1.0.2
 - r-r6=2.5.1
 - r-ragg=1.3.3
@@ -545,7 +546,7 @@ dependencies:
 - r-viridislite=0.4.2
 - r-vroom=1.6.5
 - r-waldo=0.5.3
-- r-withr=3.0.1
+- r-withr=3.0.2
 - r-xfun=0.48
 - r-xml=3.99_0.17
 - r-xml2=1.3.6
@@ -595,7 +596,7 @@ dependencies:
 - tornado=6.4.1
 - traitlets=5.9.0
 - trf=4.09.1
-- typeguard=4.3.0
+- typeguard=4.4.0
 - types-python-dateutil=2.9.0.20241003
 - typing-extensions=4.12.2
 - typing_extensions=4.12.2

--- a/2024.10/pathogenome/released/seed-environment-conda.yml
+++ b/2024.10/pathogenome/released/seed-environment-conda.yml
@@ -21,6 +21,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0

--- a/2024.10/pathogenome/staged/seed-environment-conda.yml
+++ b/2024.10/pathogenome/staged/seed-environment-conda.yml
@@ -22,6 +22,7 @@ dependencies:
 - q2-feature-classifier=2024.10.0
 - q2-feature-table=2024.10.0
 - q2-longitudinal=2024.10.0
+- q2-metadata=2024.10.0
 - q2-mystery-stew=2024.10.0
 - q2-quality-control=2024.10.0
 - q2-sample-classifier=2024.10.0


### PR DESCRIPTION
Third PR opened after we realized that q2-metadata was needed to accommodate transformers in amrfinderplus & viromics:
```
ViromicsMetadata -> Metadata
AMRFinderPlusAnnotations -> Metadata
```
This allows for `metadata tabulate` to be called on the input result types listed above.