### PR TITLE
IMP: update cron prepare to run next distro on failure

### DIFF
--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -20,7 +20,7 @@ jobs:
 
   metagenome:
     needs: [amplicon]
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'cancelled') }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:
@@ -28,7 +28,7 @@ jobs:
 
   pathogenome:
     needs: [metagenome]
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'cancelled') }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -13,6 +13,7 @@ jobs:
 
   amplicon:
     needs: [tiny]
+    if: always()
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:
@@ -20,6 +21,7 @@ jobs:
 
   metagenome:
     needs: [amplicon]
+    if: always()
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:
@@ -27,6 +29,7 @@ jobs:
 
   pathogenome:
     needs: [metagenome]
+    if: always()
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -20,7 +20,7 @@ jobs:
 
   metagenome:
     needs: [amplicon]
-    if: always()
+    if: ${{ always() }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:
@@ -28,7 +28,7 @@ jobs:
 
   pathogenome:
     needs: [metagenome]
-    if: always()
+    if: ${{ always() }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -19,7 +19,7 @@ jobs:
       distro: amplicon
 
   metagenome:
-    needs: [amplicon]
+    needs: [tiny, amplicon]
     if: ${{ always() && !cancelled() && !contains(needs.tiny.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
@@ -27,7 +27,7 @@ jobs:
       distro: metagenome
 
   pathogenome:
-    needs: [metagenome]
+    needs: [tiny, amplicon, metagenome]
     if: ${{ always() && !cancelled() && !contains(needs.tiny.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit

--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -20,7 +20,7 @@ jobs:
 
   metagenome:
     needs: [amplicon]
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() && !cancelled() && !contains(needs.tiny.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:
@@ -28,7 +28,7 @@ jobs:
 
   pathogenome:
     needs: [metagenome]
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() && !cancelled() && !contains(needs.tiny.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:

--- a/.github/workflows/cron-prepare.yaml
+++ b/.github/workflows/cron-prepare.yaml
@@ -13,7 +13,6 @@ jobs:
 
   amplicon:
     needs: [tiny]
-    if: always()
     uses: ./.github/workflows/create-prepare-pr.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
updates the cron-prepare workflow so that each distro job will run in succession, regardless of whether the previous distro failed. this update is just for amplicon, metagenome and pathogenome, to account for any isolated issues within one of these three distros. if tiny fails, we expect that all four distros will fail, so this hasn't been added for the tiny distro.