### PR TITLE
Rename q2-moshpit to q2-annotate

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -79,7 +79,7 @@ packages:
   repo: qiime2/q2-metadata
   distros: [tiny, amplicon, moshpit]
 
-- name: q2-moshpit
+- name: q2-annotate
   repo: bokulich-lab/q2-moshpit
   distros: [moshpit]
 


### PR DESCRIPTION
This PR updates the plugin name from q2-moshpit to q2-annotate.

~~Depends on https://github.com/bokulich-lab/q2-moshpit/pull/230.~~
