### PR TITLE
IMP: adds manual GHA trigger to update a stale dev epoch tag

### DIFF
--- a/.github/workflows/update-dev-epoch-tag.yaml
+++ b/.github/workflows/update-dev-epoch-tag.yaml
@@ -10,7 +10,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      new-dev-epoch: ${{ fromJSON(steps.yaml.outputs.data).next_epoch }}
+      new-dev-epoch: ${{ fromJSON(steps.yaml.outputs.data).active_epoch }}
       plugin-matrix: ${{ steps.yaml.outputs.data }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/update-dev-epoch-tag.yaml
+++ b/.github/workflows/update-dev-epoch-tag.yaml
@@ -1,0 +1,54 @@
+name: update-dev-epoch-tag
+on:
+  workflow_dispatch:
+    inputs:
+      old-dev-epoch:
+        required: true
+        type: string
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      new-dev-epoch: ${{ fromJSON(steps.yaml.outputs.data).next_epoch }}
+      plugin-matrix: ${{ steps.yaml.outputs.data }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: qiime2/distributions
+          sparse-checkout: |
+            data.yaml
+      - name: "get distro info"
+        id: yaml
+        uses: qiime2/distributions/.github/actions/read-yaml@dev
+        with:
+          file: data.yaml
+
+  update-tags:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    env:
+      OLD_DEV_TAG: ${{ inputs.old-dev-epoch }}.0.dev0
+      NEW_DEV_TAG: ${{ needs.setup.outputs.new-dev-epoch }}.0.dev0
+    strategy:
+      fail-fast: false
+      matrix:
+        packages: ${{ fromJSON(needs.setup.outputs.plugin-matrix).packages }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ./dev-checkout
+          token: ${{ secrets.BOT_PAT }}
+          repository: ${{ matrix.packages.repo }}
+
+      - name: "checkout main branch, remove old tag, commit for new dev epoch"
+        shell: bash
+        run: |
+          cd ./dev-checkout
+          git config --global user.name 'q2d2'
+          git config --global user.email 'q2d2.noreply@gmail.com'
+          git push --delete origin "${{ env.OLD_DEV_TAG }}"
+          git commit --allow-empty -m "DEV: ${{ needs.setup.outputs.new-dev-epoch }} [skip ci]"
+          git tag -a "${{ env.NEW_DEV_TAG }}" -m "${{ matrix.packages.name }} ${{ env.NEW_DEV_TAG }}"
+          git push origin --tags "${{ env.NEW_DEV_TAG }}"
+          git push origin


### PR DESCRIPTION
this manual trigger allows us to remove stale dev epoch tags and replace them with a new dev tag/commit in the (inevitable) situation where we change our minds about the upcoming release date.

PRE-REQ TO RUNNING THIS: the updated dev & dev+1 epochs need to be updated in data.yaml