### PR TITLE
perf: use uv and ruff to speed up action

### DIFF
--- a/.github/workflows/lib-ci-dev.yaml
+++ b/.github/workflows/lib-ci-dev.yaml
@@ -169,15 +169,18 @@ jobs:
       with:
         python-version: '3.10'
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+
     - name: install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -q toml
-        pip install -q https://github.com/qiime2/q2lint/archive/master.zip
-        pip install -q flake8
+        uv venv
+        uv pip install -q toml https://github.com/qiime2/q2lint/archive/master.zip
 
-    - name: run flake8
-      run: flake8
+    - name: run ruff
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: "check --output-format=github"
 
     - name: run q2lint
-      run: q2lint
+      run: uv run q2lint


### PR DESCRIPTION
This PR introduces the idea of using uv instead of pip and ruff instead of flake8 for the purpose of speeding up the `lib-ci-dev.yaml` github action. Let's see what happens! It's possilbe this could dramatically reduce CI run times.

## references
- https://docs.astral.sh/uv/
- https://docs.astral.sh/ruff/

<img width="496" height="107" alt="image" src="https://github.com/user-attachments/assets/1e89d8ed-fd72-41c0-bc90-dee23bc41364" />

<img width="585" height="167" alt="image" src="https://github.com/user-attachments/assets/0262b045-a6aa-46a0-a7f0-77994821f2ab" />
