### PR TITLE
Update busco to 6.0.0

### DIFF
--- a/2025.10/moshpit/passed/seed-environment-conda.yml
+++ b/2025.10/moshpit/passed/seed-environment-conda.yml
@@ -6,6 +6,7 @@ dependencies:
 - biom-format=2.1.16
 - biopython=1.83
 - bowtie2=2.5.1
+- busco=6.0.0
 - click=8.1.8
 - entrezpy=2.1.2
 - fastp=0.24.0

--- a/2025.10/moshpit/staged/seed-environment-conda.yml
+++ b/2025.10/moshpit/staged/seed-environment-conda.yml
@@ -6,7 +6,7 @@ dependencies:
 - biom-format=2.1.16
 - biopython=1.83
 - bowtie2=2.5.1
-- busco=6.0.0
+- busco=5.5.0
 - click=8.1.8
 - entrezpy=2.1.2
 - fastp=0.24.0

--- a/2025.10/moshpit/staged/seed-environment-conda.yml
+++ b/2025.10/moshpit/staged/seed-environment-conda.yml
@@ -6,7 +6,7 @@ dependencies:
 - biom-format=2.1.16
 - biopython=1.83
 - bowtie2=2.5.1
-- busco=5.5.0
+- busco=6.0.0
 - click=8.1.8
 - entrezpy=2.1.2
 - fastp=0.24.0


### PR DESCRIPTION
This PR updates `BUSCO` version to `6.0.0`.