### PR TITLE
Add semibin to the moshpit distro

### DIFF
--- a/2025.10/moshpit/passed/seed-environment-conda.yml
+++ b/2025.10/moshpit/passed/seed-environment-conda.yml
@@ -58,6 +58,7 @@ dependencies:
 - scikit-learn=1.4.2
 - scipy=1.13.0
 - seaborn=0.12.2
+- semibin=2.2.0
 - sepp=4.5.5
 - spades=4.0.0
 - tqdm=4.62.3


### PR DESCRIPTION
This PR adds `semibin` to the MOSHPIT distribution.
