### PR TITLE
MAINT: pin ncbi-amrfinderplus in pathogenome distro

### DIFF
--- a/2025.10/pathogenome/passed/seed-environment-conda.yml
+++ b/2025.10/pathogenome/passed/seed-environment-conda.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
+- ncbi-amrfinderplus=4.0.23
 - biom-format=2.1.16
 - blast=2.16.0
 - bowtie2=2.5.1

--- a/2025.10/pathogenome/released/seed-environment-conda.yml
+++ b/2025.10/pathogenome/released/seed-environment-conda.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
+- ncbi-amrfinderplus=4.0.23
 - biom-format=2.1.16
 - blast=2.16.0
 - bowtie2=2.5.1

--- a/2025.10/pathogenome/staged/seed-environment-conda.yml
+++ b/2025.10/pathogenome/staged/seed-environment-conda.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - bioconda
 dependencies:
+- ncbi-amrfinderplus=4.0.23
 - biom-format=2.1.16
 - blast=2.16.0
 - bowtie2=2.5.1


### PR DESCRIPTION
When installing the pathogenome distribution of QIIME2, the version 3.12.8 of ncbi-amrfinderplus is installed and not the latest. This is because an issue with the solver choosing an r-rcurl build that uses an older curl version (8.8.0) and that forces an older version of amrfindeprlus.

By pinning ncbi-amrfinderplus to the version 4.0.23 this issue gets resolved. 
