### PR TITLE
MAINT: split workflows by OS

### DIFF
--- a/.github/workflows/ci-distro-trial-linux.yaml
+++ b/.github/workflows/ci-distro-trial-linux.yaml
@@ -1,0 +1,173 @@
+name: ci-distro-trial-linux
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 20*.*/*/passed/seed-environment-conda.yml
+      - 20*.*/*/released/seed-environment-conda.yml
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    uses: ./.github/workflows/ci-distro-trial_0-prepare-linux.yaml
+
+  rebuild-0:
+    needs: [prepare]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[0] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 0
+
+  rebuild-1:
+    needs: [prepare, rebuild-0]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[1] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 1
+
+  rebuild-2:
+    needs: [prepare, rebuild-1]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[2] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 2
+
+  rebuild-3:
+    needs: [prepare, rebuild-2]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[3] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 3
+
+  rebuild-4:
+    needs: [prepare, rebuild-3]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[4] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 4
+
+  rebuild-5:
+    needs: [prepare, rebuild-4]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[5] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 5
+
+  rebuild-6:
+    needs: [prepare, rebuild-5]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[6] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 6
+
+  rebuild-7:
+    needs: [prepare, rebuild-6]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[7] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 7
+
+  build-metapackage:
+    needs: [prepare, rebuild-0, rebuild-1, rebuild-2, rebuild-3, rebuild-4, rebuild-5, rebuild-6, rebuild-7]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    uses: ./.github/workflows/ci-distro-trial_2-build-metapackage-linux.yaml
+    with:
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      solved-environment-key: ${{ needs.prepare.outputs.solved-environment-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      distro-name: qiime2-${{ needs.prepare.outputs.distro }}
+
+  test-metapackage:
+    needs: [prepare, build-metapackage]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    uses: ./.github/workflows/ci-distro-trial_3-test-metapackage-linux.yaml
+    with:
+      solved-environment-key: ${{ needs.prepare.outputs.solved-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      distro-name: qiime2-${{ needs.prepare.outputs.distro }}
+
+  upload-builds:
+    needs: [prepare, test-metapackage]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    uses: ./.github/workflows/ci-distro-trial_4-upload-builds.yaml
+    secrets: inherit
+    with:
+      epoch: ${{ needs.prepare.outputs.epoch }}
+      distro: ${{ needs.prepare.outputs.distro }}
+      is-release: ${{ needs.prepare.outputs.is-release }}
+      pr-ref: ${{ github.event.pull_request.head.ref }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      solved-environment-key: ${{ needs.prepare.outputs.solved-environment-key }}
+      repodata-patches-key: ${{ needs.prepare.outputs.repodata-patches-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}

--- a/.github/workflows/ci-distro-trial-osx.yaml
+++ b/.github/workflows/ci-distro-trial-osx.yaml
@@ -1,0 +1,173 @@
+name: ci-distro-trial-osx
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 20*.*/*/passed/seed-environment-conda.yml
+      - 20*.*/*/released/seed-environment-conda.yml
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    uses: ./.github/workflows/ci-distro-trial_0-prepare-osx.yaml
+
+  rebuild-0:
+    needs: [prepare]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[0] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 0
+
+  rebuild-1:
+    needs: [prepare, rebuild-0]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[1] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 1
+
+  rebuild-2:
+    needs: [prepare, rebuild-1]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[2] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 2
+
+  rebuild-3:
+    needs: [prepare, rebuild-2]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[3] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 3
+
+  rebuild-4:
+    needs: [prepare, rebuild-3]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[4] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 4
+
+  rebuild-5:
+    needs: [prepare, rebuild-4]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[5] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 5
+
+  rebuild-6:
+    needs: [prepare, rebuild-5]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[6] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 6
+
+  rebuild-7:
+    needs: [prepare, rebuild-6]
+    if: ${{ fromJSON(needs.prepare.outputs.generation-matrix)[7] != null }}
+    uses: ./.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+    with:
+      is-language: ${{ needs.prepare.outputs.is-language }}
+      is-rebuild: ${{ needs.prepare.outputs.is-rebuild }}
+      rev-deps-key: ${{ needs.prepare.outputs.rev-deps-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      sibling-ref: ${{ needs.prepare.outputs.sibling-ref }}
+      matrix-index: 7
+
+  build-metapackage:
+    needs: [prepare, rebuild-0, rebuild-1, rebuild-2, rebuild-3, rebuild-4, rebuild-5, rebuild-6, rebuild-7]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    uses: ./.github/workflows/ci-distro-trial_2-build-metapackage-osx.yaml
+    with:
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      solved-environment-key: ${{ needs.prepare.outputs.solved-environment-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      distro-name: qiime2-${{ needs.prepare.outputs.distro }}
+
+  test-metapackage:
+    needs: [prepare, build-metapackage]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    uses: ./.github/workflows/ci-distro-trial_3-test-metapackage-osx.yaml
+    with:
+      solved-environment-key: ${{ needs.prepare.outputs.solved-environment-key }}
+      matrix-key: ${{ needs.prepare.outputs.matrix-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}
+      patched-channel-key: ${{ needs.prepare.outputs.patched-channel-key }}
+      distro-name: qiime2-${{ needs.prepare.outputs.distro }}
+
+  upload-builds:
+    needs: [prepare, test-metapackage]
+    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    uses: ./.github/workflows/ci-distro-trial_4-upload-builds.yaml
+    secrets: inherit
+    with:
+      epoch: ${{ needs.prepare.outputs.epoch }}
+      distro: ${{ needs.prepare.outputs.distro }}
+      is-release: ${{ needs.prepare.outputs.is-release }}
+      pr-ref: ${{ github.event.pull_request.head.ref }}
+      seed-environment-key: ${{ needs.prepare.outputs.seed-environment-key }}
+      solved-environment-key: ${{ needs.prepare.outputs.solved-environment-key }}
+      repodata-patches-key: ${{ needs.prepare.outputs.repodata-patches-key }}
+      rebuilt-channel-key: ${{ needs.prepare.outputs.rebuilt-channel-key }}

--- a/.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
+++ b/.github/workflows/ci-distro-trial_1-build-generation-linux.yaml
@@ -1,0 +1,340 @@
+on:
+  workflow_call:
+    inputs:
+      rev-deps-key:
+        required: true
+        type: string
+      patched-channel-key:
+        required: true
+        type: string
+      rebuilt-channel-key:
+        required: true
+        type: string
+      seed-environment-key:
+        required: true
+        type: string
+      matrix-key:
+        required: true
+        type: string
+      matrix-index:
+        required: true
+        type: number
+      sibling-ref:
+        required: true
+        type: string
+      is-rebuild:
+        required: true
+        type: string
+      is-language:
+        required: true
+        type: string
+
+env:
+  matrix_path: './matrix'
+  rebuilt_channel_path: './rebuilt-channel'
+  patched_channel_path: './patched-channel'
+  rev_deps_path: './rev-deps'
+  seed_environment_path: './seed-env'
+  plugin_path: './plugin'
+  version_key: '(Version Files) Rebuilt version info'
+  version_path: './version-info'
+  repodata_patches_key: '(Repodata Patches) patch_instructions.json'
+  repodata_patches_path: './repodata-patches'
+
+jobs:
+  configure_matrix:
+    name: 'Set up build matrix'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.matrix-key }}
+          path: '${{ env.matrix_path }}'
+
+      - id: set-matrix
+        run: |
+          echo "matrix=$(cat ${{ env.matrix_path }}/rebuild_matrix.json)" >> $GITHUB_OUTPUT
+
+
+  run_matrix:
+    name: '${{ matrix.package }} (linux-alma9)'
+    needs: configure_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.configure_matrix.outputs.matrix)[inputs.matrix-index] }}
+    runs-on: ubuntu-latest
+    container:
+      image: condaforge/linux-anvil-alma-aarch64:9
+    steps:
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - shell: bash
+        run: pip install pyyaml
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch rebuilt channel'
+        with:
+          pattern: ${{ inputs.rebuilt-channel-key }}-*
+          path: ${{ env.rebuilt_channel_path }}
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch seed environment.yml'
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+
+      - name: Try to retrieve branch name
+        if: ${{ inputs.is-language == 'true' }}
+        # Replaces octokit/request-action@v2.x
+        uses: qiime2-cutlery/request-action@v2.x
+        id: get-branch
+        with:
+          route: GET /repos/${{ matrix.package }}/branches/${{ inputs.sibling-ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Determine which branch to checkout
+        if: ${{ inputs.is-language == 'true' }}
+        id: sibling-ref
+        run: |
+          if [[ '${{ steps.get-branch.outputs.status }}' = '200' ]]; then
+            sibling_ref="${{ inputs.sibling-ref }}"
+          else
+            sibling_ref=""
+          fi
+          echo "sibling-ref=$sibling_ref" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v3
+        if: ${{ inputs.is-language == 'true' }}
+        name: 'Checkout ${{ matrix.package }} repository'
+        with:
+          repository: ${{ matrix.package }}
+          ref: ${{ steps.sibling-ref.outputs.sibling-ref }}
+          path: ${{ env.plugin_path }}
+          fetch-depth: 0
+
+      - uses: actions/checkout@v3
+        if: ${{ inputs.is-language != 'true' }}
+        name: 'Checkout ${{ matrix.package }} repository'
+        with:
+          repository: ${{ matrix.package }}
+          ref: ${{ inputs.sibling-ref }}
+          path: ${{ env.plugin_path }}
+          fetch-depth: 0
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - uses: qiime2/action-library-packaging/build-package@beta
+        name: 'Determine package data for ${{ matrix.package }}'
+        id: get-package-data
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          recipe-path: ${{ env.plugin_path }}/conda-recipe/
+          conda-build-config: ${{ steps.make-cbc.outputs.conda-build-config }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+          output-channel: ${{ env.rebuilt_channel_path }}
+          dry-run: true
+
+      - uses: actions/cache/restore@v3
+        name: 'Try to fetch an existing build'
+        id: fetch-build
+        with:
+          key: "(Conda Package) ${{ steps.get-package-data.outputs.package-name }}=${{ steps.get-package-data.outputs.package-version }} (linux-alma9) (${{ hashFiles(format('{0}/seed-environment-conda.yml', env.seed_environment_path)) }})"
+          path: ${{ env.rebuilt_channel_path }}/*/${{ steps.get-package-data.outputs.package-name}}-${{ steps.get-package-data.outputs.package-version}}-*
+
+      - uses: qiime2/action-library-packaging/make-conda-config@beta
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Create conda build config'
+        id: make-cbc
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          seed-environment: '${{ env.seed_environment_path }}/seed-environment-conda.yml'
+          conda-build-config: 'conda_build_config.yml'
+          channels: '["${{ env.rebuilt_channel_path }}", "${{ env.patched_channel_path }}"]'
+          skip-first-channel: true
+
+      - uses: qiime2/action-library-packaging/build-package@beta
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Build ${{ matrix.package }}'
+        id: build-package
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          recipe-path: ${{ env.plugin_path }}/conda-recipe/
+          conda-build-config: ${{ steps.make-cbc.outputs.conda-build-config }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+          output-channel: ${{ env.rebuilt_channel_path }}
+
+      - uses: actions/cache/save@v3
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Cache build of ${{ matrix.package }}'
+        id: cache-build
+        with:
+          key: ${{ steps.fetch-build.outputs.cache-primary-key }}
+          path: ${{ env.rebuilt_channel_path }}/*/${{ steps.get-package-data.outputs.package-name}}-${{ steps.get-package-data.outputs.package-version}}-*
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload updated build to rebuilt channel'
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}-${{ steps.get-package-data.outputs.package-name }}-linux-alma9
+          path: ${{ env.rebuilt_channel_path }}/*/${{ steps.get-package-data.outputs.package-name }}-${{ steps.get-package-data.outputs.package-version }}-*
+
+      - id: setup-version-info
+        name: 'Capture info about package'
+        shell: bash
+        run: |
+          mkdir -p ${{ env.version_path }}
+          echo '${{ steps.get-package-data.outputs.package-name }}=${{ steps.get-package-data.outputs.package-version }}' > '${{ env.version_path }}/${{ steps.get-package-data.outputs.package-name }}.txt'
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload info about package'
+        with:
+          name: ${{ env.version_key }}-${{ steps.get-package-data.outputs.package-name }}-linux-alma9
+          path: ${{ env.version_path }}
+
+
+  finalize:
+    name: 'Finalize generation'
+    needs: [run_matrix]
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v4
+        name: 'Collate rebuilt channel'
+        with:
+          pattern: ${{ inputs.rebuilt-channel-key }}-*
+          path: ${{ env.rebuilt_channel_path }}
+          merge-multiple: true
+
+      - name: set up python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: install pyyaml & packaging
+        shell: bash
+        run: pip install pyyaml packaging
+
+      - name: install conda-build
+        run: conda install -c conda-forge -q conda-build
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - name: 'Reindex rebuilt channel'
+        shell: bash
+        run: |
+          ${{ steps.setup-conda.outputs.conda-activate }}
+          python -m conda_index ${{ env.rebuilt_channel_path }}
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload final rebuilt channel'
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: |
+            ${{ env.rebuilt_channel_path }}/**
+            !${{ env.rebuilt_channel_path }}/*/.cache/*
+          overwrite: true
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch updated versions'
+        with:
+          pattern: ${{ env.version_key }}-*
+          path: ${{ env.version_path }}
+          merge-multiple: true
+
+      - name: 'Collated updated versions'
+        shell: bash
+        run: cat ${{ env.version_path }}/*.txt > version_updates.txt
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch seed environment.yml'
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+
+      - uses: qiime2/action-library-packaging/patch-env@beta
+        name: 'Update seed environment file with new versions'
+        with:
+          environment-file: ${{ env.seed_environment_path }}/seed-environment-conda.yml
+          versions-file: version_updates.txt
+
+      - uses: actions/upload-artifact@v4
+        name: 'Update seed environment.yml'
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+          overwrite: true
+
+      - uses: actions/download-artifact@v4
+        if: ${{ inputs.is-rebuild != 'true' }}
+        name: 'Fetch base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - uses: actions/download-artifact@v4
+        if: ${{ inputs.is-rebuild != 'true' }}
+        name: 'Fetch rebuilt packages and their reverse dependencies'
+        with:
+          name: ${{ inputs.rev-deps-key }}
+          path: ${{ env.rev_deps_path }}
+
+      - name: 'Patch base channel'
+        if: ${{ inputs.is-rebuild != 'true' }}
+        uses: qiime2/action-library-packaging/patch-repodata@beta
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          channel: ${{ env.patched_channel_path }}
+          rev-deps: ${{ env.rev_deps_path }}/rev_deps.json
+          versions-file: version_updates.txt
+
+      - name: copy repodata patches
+        if: ${{ inputs.is-rebuild != 'true' }}
+        run: |
+          mkdir -p ${{ env.repodata_patches_path }}/linux-64
+          mkdir -p ${{ env.repodata_patches_path }}/osx-64
+          mkdir -p ${{ env.repodata_patches_path }}/noarch
+
+          cp ${{ env.patched_channel_path }}/linux-64/patch_instructions.json \
+             ${{ env.repodata_patches_path }}/linux-64/patch_instructions.json
+
+          cp ${{ env.patched_channel_path }}/osx-64/patch_instructions.json \
+             ${{ env.repodata_patches_path }}/osx-64/patch_instructions.json
+
+          cp ${{ env.patched_channel_path }}/noarch/patch_instructions.json \
+             ${{ env.repodata_patches_path }}/noarch/patch_instructions.json
+
+      - name: store repodata patches
+        if: ${{ inputs.is-rebuild != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.repodata_patches_key }}
+          path: ${{ env.repodata_patches_path }}
+          overwrite: true
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.is-rebuild != 'true' }}
+        name: 'Upload base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+          overwrite: true

--- a/.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
+++ b/.github/workflows/ci-distro-trial_1-build-generation-osx.yaml
@@ -1,0 +1,338 @@
+on:
+  workflow_call:
+    inputs:
+      rev-deps-key:
+        required: true
+        type: string
+      patched-channel-key:
+        required: true
+        type: string
+      rebuilt-channel-key:
+        required: true
+        type: string
+      seed-environment-key:
+        required: true
+        type: string
+      matrix-key:
+        required: true
+        type: string
+      matrix-index:
+        required: true
+        type: number
+      sibling-ref:
+        required: true
+        type: string
+      is-rebuild:
+        required: true
+        type: string
+      is-language:
+        required: true
+        type: string
+
+env:
+  matrix_path: './matrix'
+  rebuilt_channel_path: './rebuilt-channel'
+  patched_channel_path: './patched-channel'
+  rev_deps_path: './rev-deps'
+  seed_environment_path: './seed-env'
+  plugin_path: './plugin'
+  version_key: '(Version Files) Rebuilt version info'
+  version_path: './version-info'
+  repodata_patches_key: '(Repodata Patches) patch_instructions.json'
+  repodata_patches_path: './repodata-patches'
+
+jobs:
+  configure_matrix:
+    name: 'Set up build matrix'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.matrix-key }}
+          path: '${{ env.matrix_path }}'
+
+      - id: set-matrix
+        run: |
+          echo "matrix=$(cat ${{ env.matrix_path }}/rebuild_matrix.json)" >> $GITHUB_OUTPUT
+
+
+  run_matrix:
+    name: '${{ matrix.package }} (macos-15-intel)'
+    needs: configure_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.configure_matrix.outputs.matrix)[inputs.matrix-index] }}
+    runs-on: macos-15-intel
+    steps:
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - shell: bash
+        run: pip install pyyaml
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch rebuilt channel'
+        with:
+          pattern: ${{ inputs.rebuilt-channel-key }}-*
+          path: ${{ env.rebuilt_channel_path }}
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch seed environment.yml'
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+
+      - name: Try to retrieve branch name
+        if: ${{ inputs.is-language == 'true' }}
+        # Replaces octokit/request-action@v2.x
+        uses: qiime2-cutlery/request-action@v2.x
+        id: get-branch
+        with:
+          route: GET /repos/${{ matrix.package }}/branches/${{ inputs.sibling-ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Determine which branch to checkout
+        if: ${{ inputs.is-language == 'true' }}
+        id: sibling-ref
+        run: |
+          if [[ '${{ steps.get-branch.outputs.status }}' = '200' ]]; then
+            sibling_ref="${{ inputs.sibling-ref }}"
+          else
+            sibling_ref=""
+          fi
+          echo "sibling-ref=$sibling_ref" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v3
+        if: ${{ inputs.is-language == 'true' }}
+        name: 'Checkout ${{ matrix.package }} repository'
+        with:
+          repository: ${{ matrix.package }}
+          ref: ${{ steps.sibling-ref.outputs.sibling-ref }}
+          path: ${{ env.plugin_path }}
+          fetch-depth: 0
+
+      - uses: actions/checkout@v3
+        if: ${{ inputs.is-language != 'true' }}
+        name: 'Checkout ${{ matrix.package }} repository'
+        with:
+          repository: ${{ matrix.package }}
+          ref: ${{ inputs.sibling-ref }}
+          path: ${{ env.plugin_path }}
+          fetch-depth: 0
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - uses: qiime2/action-library-packaging/build-package@beta
+        name: 'Determine package data for ${{ matrix.package }}'
+        id: get-package-data
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          recipe-path: ${{ env.plugin_path }}/conda-recipe/
+          conda-build-config: ${{ steps.make-cbc.outputs.conda-build-config }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+          output-channel: ${{ env.rebuilt_channel_path }}
+          dry-run: true
+
+      - uses: actions/cache/restore@v3
+        name: 'Try to fetch an existing build'
+        id: fetch-build
+        with:
+          key: "(Conda Package) ${{ steps.get-package-data.outputs.package-name }}=${{ steps.get-package-data.outputs.package-version }} (macos-15-intel) (${{ hashFiles(format('{0}/seed-environment-conda.yml', env.seed_environment_path)) }})"
+          path: ${{ env.rebuilt_channel_path }}/*/${{ steps.get-package-data.outputs.package-name}}-${{ steps.get-package-data.outputs.package-version}}-*
+
+      - uses: qiime2/action-library-packaging/make-conda-config@beta
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Create conda build config'
+        id: make-cbc
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          seed-environment: '${{ env.seed_environment_path }}/seed-environment-conda.yml'
+          conda-build-config: 'conda_build_config.yml'
+          channels: '["${{ env.rebuilt_channel_path }}", "${{ env.patched_channel_path }}"]'
+          skip-first-channel: true
+
+      - uses: qiime2/action-library-packaging/build-package@beta
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Build ${{ matrix.package }}'
+        id: build-package
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          recipe-path: ${{ env.plugin_path }}/conda-recipe/
+          conda-build-config: ${{ steps.make-cbc.outputs.conda-build-config }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+          output-channel: ${{ env.rebuilt_channel_path }}
+
+      - uses: actions/cache/save@v3
+        if: ${{ !steps.fetch-build.outputs.cache-hit }}
+        name: 'Cache build of ${{ matrix.package }}'
+        id: cache-build
+        with:
+          key: ${{ steps.fetch-build.outputs.cache-primary-key }}
+          path: ${{ env.rebuilt_channel_path }}/*/${{ steps.get-package-data.outputs.package-name}}-${{ steps.get-package-data.outputs.package-version}}-*
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload updated build to rebuilt channel'
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}-${{ steps.get-package-data.outputs.package-name }}-macos-15-intel
+          path: ${{ env.rebuilt_channel_path }}/*/${{ steps.get-package-data.outputs.package-name }}-${{ steps.get-package-data.outputs.package-version }}-*
+
+      - id: setup-version-info
+        name: 'Capture info about package'
+        shell: bash
+        run: |
+          mkdir -p ${{ env.version_path }}
+          echo '${{ steps.get-package-data.outputs.package-name }}=${{ steps.get-package-data.outputs.package-version }}' > '${{ env.version_path }}/${{ steps.get-package-data.outputs.package-name }}.txt'
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload info about package'
+        with:
+          name: ${{ env.version_key }}-${{ steps.get-package-data.outputs.package-name }}-macos-15-intel
+          path: ${{ env.version_path }}
+
+
+  finalize:
+    name: 'Finalize generation'
+    needs: [run_matrix]
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v4
+        name: 'Collate rebuilt channel'
+        with:
+          pattern: ${{ inputs.rebuilt-channel-key }}-*
+          path: ${{ env.rebuilt_channel_path }}
+          merge-multiple: true
+
+      - name: set up python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: install pyyaml & packaging
+        shell: bash
+        run: pip install pyyaml packaging
+
+      - name: install conda-build
+        run: conda install -c conda-forge -q conda-build
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - name: 'Reindex rebuilt channel'
+        shell: bash
+        run: |
+          ${{ steps.setup-conda.outputs.conda-activate }}
+          python -m conda_index ${{ env.rebuilt_channel_path }}
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload final rebuilt channel'
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: |
+            ${{ env.rebuilt_channel_path }}/**
+            !${{ env.rebuilt_channel_path }}/*/.cache/*
+          overwrite: true
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch updated versions'
+        with:
+          pattern: ${{ env.version_key }}-*
+          path: ${{ env.version_path }}
+          merge-multiple: true
+
+      - name: 'Collated updated versions'
+        shell: bash
+        run: cat ${{ env.version_path }}/*.txt > version_updates.txt
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch seed environment.yml'
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+
+      - uses: qiime2/action-library-packaging/patch-env@beta
+        name: 'Update seed environment file with new versions'
+        with:
+          environment-file: ${{ env.seed_environment_path }}/seed-environment-conda.yml
+          versions-file: version_updates.txt
+
+      - uses: actions/upload-artifact@v4
+        name: 'Update seed environment.yml'
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+          overwrite: true
+
+      - uses: actions/download-artifact@v4
+        if: ${{ inputs.is-rebuild != 'true' }}
+        name: 'Fetch base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - uses: actions/download-artifact@v4
+        if: ${{ inputs.is-rebuild != 'true' }}
+        name: 'Fetch rebuilt packages and their reverse dependencies'
+        with:
+          name: ${{ inputs.rev-deps-key }}
+          path: ${{ env.rev_deps_path }}
+
+      - name: 'Patch base channel'
+        if: ${{ inputs.is-rebuild != 'true' }}
+        uses: qiime2/action-library-packaging/patch-repodata@beta
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          channel: ${{ env.patched_channel_path }}
+          rev-deps: ${{ env.rev_deps_path }}/rev_deps.json
+          versions-file: version_updates.txt
+
+      - name: copy repodata patches
+        if: ${{ inputs.is-rebuild != 'true' }}
+        run: |
+          mkdir -p ${{ env.repodata_patches_path }}/linux-64
+          mkdir -p ${{ env.repodata_patches_path }}/osx-64
+          mkdir -p ${{ env.repodata_patches_path }}/noarch
+
+          cp ${{ env.patched_channel_path }}/linux-64/patch_instructions.json \
+             ${{ env.repodata_patches_path }}/linux-64/patch_instructions.json
+
+          cp ${{ env.patched_channel_path }}/osx-64/patch_instructions.json \
+             ${{ env.repodata_patches_path }}/osx-64/patch_instructions.json
+
+          cp ${{ env.patched_channel_path }}/noarch/patch_instructions.json \
+             ${{ env.repodata_patches_path }}/noarch/patch_instructions.json
+
+      - name: store repodata patches
+        if: ${{ inputs.is-rebuild != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.repodata_patches_key }}
+          path: ${{ env.repodata_patches_path }}
+          overwrite: true
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.is-rebuild != 'true' }}
+        name: 'Upload base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+          overwrite: true

--- a/.github/workflows/ci-distro-trial_2-build-metapackage-linux.yaml
+++ b/.github/workflows/ci-distro-trial_2-build-metapackage-linux.yaml
@@ -1,0 +1,151 @@
+on:
+  workflow_call:
+    inputs:
+      seed-environment-key:
+        required: true
+        type: string
+      solved-environment-key:
+        required: true
+        type: string
+      rebuilt-channel-key:
+        required: true
+        type: string
+      patched-channel-key:
+        required: true
+        type: string
+      distro-name:
+        required: true
+        type: string
+    outputs:
+      distro-version:
+        value: ${{ jobs.setup-version.outputs.version }}
+
+env:
+  patched_channel_path: './patched-channel'
+  rebuilt_channel_path: './rebuilt-channel'
+  seed_environment_path: './seed-env'
+  environment_prefix: './test-env/'
+
+jobs:
+  setup-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.create-version.outputs.version }}
+    steps:
+      - id: create-version
+        shell: bash
+        run: |
+          echo version=$(
+            python -c "import datetime; print(datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S'))"
+          ) >> $GITHUB_OUTPUT
+
+  build-metapackage:
+    needs: [setup-version]
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: condaforge/linux-anvil-alma-aarch64:9
+    steps:
+      - uses: qiime2/action-library-packaging/clean-disk@beta
+        if: ${{ runner.os == 'Linux' }}
+        name: "Clean disk on linux"
+
+      - name: fetch seed env
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - name: fetch rebuilt channel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: ${{ env.rebuilt_channel_path }}
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        id: build-env
+        name: "Set up build env"
+
+      - uses: qiime2/action-library-packaging/build-metapackage@beta
+        name: "Build metapackage"
+        id: build-meta
+        with:
+          conda-activate: ${{ steps.build-env.outputs.conda-activate }}
+          channels: '["${{ env.rebuilt_channel_path }}", "${{ env.patched_channel_path }}"]'
+          metapackage-name: ${{ inputs.distro-name }}
+          metapackage-version: ${{ needs.setup-version.outputs.version }}
+          seed-environment: '${{ env.seed_environment_path }}/seed-environment-conda.yml'
+          output-channel: ${{ env.rebuilt_channel_path }}
+
+      - name: Install metapackage, create env file, and cache
+        id: cache-env
+        uses: qiime2/action-library-packaging/create-env@beta
+        with:
+          conda-prefix: ${{ env.environment_prefix }}
+          environment-file: ${{ inputs.distro-name }}-linux-alma9-conda.yml
+          channels: ${{ steps.build-meta.outputs.channels }}
+          package-name: ${{ inputs.distro-name }}
+          package-version: ${{ needs.setup-version.outputs.version }}
+
+      - name: upload rebuilt channel with metapackage
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}-${{ inputs.distro-name }}-linux-alma9
+          path: ${{ env.rebuilt_channel_path }}/*/${{ inputs.distro-name }}-${{ needs.setup-version.outputs.version }}-*
+
+      - name: upload environment file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.solved-environment-key }}-linux-alma9
+          path: ${{ steps.cache-env.outputs.environment-file }}
+
+  finalize:
+    name: 'Finalize metapackage'
+    needs: [build-metapackage]
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v4
+        name: 'Collate rebuilt channel'
+        with:
+          pattern: ${{ inputs.rebuilt-channel-key }}-*
+          path: ${{ env.rebuilt_channel_path }}
+          merge-multiple: true
+
+      - name: set up python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: install pyyaml & packaging
+        shell: bash
+        run: pip install pyyaml packaging
+
+      - name: install conda-build
+        run: conda install -c conda-forge -q conda-build
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - name: 'Reindex rebuilt channel'
+        shell: bash
+        run: |
+          ${{ steps.setup-conda.outputs.conda-activate }}
+          python -m conda_index ${{ env.rebuilt_channel_path }}
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload final rebuilt channel'
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: |
+            ${{ env.rebuilt_channel_path }}/**
+            !${{ env.rebuilt_channel_path }}/*/.cache/*
+          overwrite: true

--- a/.github/workflows/ci-distro-trial_2-build-metapackage-osx.yaml
+++ b/.github/workflows/ci-distro-trial_2-build-metapackage-osx.yaml
@@ -1,0 +1,149 @@
+on:
+  workflow_call:
+    inputs:
+      seed-environment-key:
+        required: true
+        type: string
+      solved-environment-key:
+        required: true
+        type: string
+      rebuilt-channel-key:
+        required: true
+        type: string
+      patched-channel-key:
+        required: true
+        type: string
+      distro-name:
+        required: true
+        type: string
+    outputs:
+      distro-version:
+        value: ${{ jobs.setup-version.outputs.version }}
+
+env:
+  patched_channel_path: './patched-channel'
+  rebuilt_channel_path: './rebuilt-channel'
+  seed_environment_path: './seed-env'
+  environment_prefix: './test-env/'
+
+jobs:
+  setup-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.create-version.outputs.version }}
+    steps:
+      - id: create-version
+        shell: bash
+        run: |
+          echo version=$(
+            python -c "import datetime; print(datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S'))"
+          ) >> $GITHUB_OUTPUT
+
+  build-metapackage:
+    needs: [setup-version]
+    strategy:
+      fail-fast: false
+    runs-on: macos-15-intel
+    steps:
+      - uses: qiime2/action-library-packaging/clean-disk@beta
+        if: ${{ runner.os == 'Linux' }}
+        name: "Clean disk on linux"
+
+      - name: fetch seed env
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.seed-environment-key }}
+          path: ${{ env.seed_environment_path }}
+
+      - uses: actions/download-artifact@v4
+        name: 'Fetch base channel with patches'
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - name: fetch rebuilt channel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: ${{ env.rebuilt_channel_path }}
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        id: build-env
+        name: "Set up build env"
+
+      - uses: qiime2/action-library-packaging/build-metapackage@beta
+        name: "Build metapackage"
+        id: build-meta
+        with:
+          conda-activate: ${{ steps.build-env.outputs.conda-activate }}
+          channels: '["${{ env.rebuilt_channel_path }}", "${{ env.patched_channel_path }}"]'
+          metapackage-name: ${{ inputs.distro-name }}
+          metapackage-version: ${{ needs.setup-version.outputs.version }}
+          seed-environment: '${{ env.seed_environment_path }}/seed-environment-conda.yml'
+          output-channel: ${{ env.rebuilt_channel_path }}
+
+      - name: Install metapackage, create env file, and cache
+        id: cache-env
+        uses: qiime2/action-library-packaging/create-env@beta
+        with:
+          conda-prefix: ${{ env.environment_prefix }}
+          environment-file: ${{ inputs.distro-name }}-macos-15-intel-conda.yml
+          channels: ${{ steps.build-meta.outputs.channels }}
+          package-name: ${{ inputs.distro-name }}
+          package-version: ${{ needs.setup-version.outputs.version }}
+
+      - name: upload rebuilt channel with metapackage
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}-${{ inputs.distro-name }}-macos-15-intel
+          path: ${{ env.rebuilt_channel_path }}/*/${{ inputs.distro-name }}-${{ needs.setup-version.outputs.version }}-*
+
+      - name: upload environment file
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.solved-environment-key }}-macos-15-intel
+          path: ${{ steps.cache-env.outputs.environment-file }}
+
+  finalize:
+    name: 'Finalize metapackage'
+    needs: [build-metapackage]
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/download-artifact@v4
+        name: 'Collate rebuilt channel'
+        with:
+          pattern: ${{ inputs.rebuilt-channel-key }}-*
+          path: ${{ env.rebuilt_channel_path }}
+          merge-multiple: true
+
+      - name: set up python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: install pyyaml & packaging
+        shell: bash
+        run: pip install pyyaml packaging
+
+      - name: install conda-build
+        run: conda install -c conda-forge -q conda-build
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - name: 'Reindex rebuilt channel'
+        shell: bash
+        run: |
+          ${{ steps.setup-conda.outputs.conda-activate }}
+          python -m conda_index ${{ env.rebuilt_channel_path }}
+
+      - uses: actions/upload-artifact@v4
+        name: 'Upload final rebuilt channel'
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: |
+            ${{ env.rebuilt_channel_path }}/**
+            !${{ env.rebuilt_channel_path }}/*/.cache/*
+          overwrite: true

--- a/.github/workflows/ci-distro-trial_3-test-metapackage-linux.yaml
+++ b/.github/workflows/ci-distro-trial_3-test-metapackage-linux.yaml
@@ -1,0 +1,110 @@
+on:
+  workflow_call:
+    inputs:
+      solved-environment-key:
+        required: true
+        type: string
+      matrix-key:
+        required: true
+        type: string
+      rebuilt-channel-key:
+        required: true
+        type: string
+      patched-channel-key:
+        required: true
+        type: string
+      distro-name:
+        required: true
+        type: string
+
+env:
+  matrix_path: './matrix'
+  solved_environment_path: './env-file'
+  patched_channel_path: './patched-channel'
+  rebuilt_channel_path: './rebuilt-channel'
+
+jobs:
+  configure_matrix:
+    name: 'Set up build matrix'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.matrix-key }}
+          path: '${{ env.matrix_path }}'
+
+      - id: set-matrix
+        run: |
+          echo "matrix=$(cat ${{ env.matrix_path }}/retest_matrix.json)" >> $GITHUB_OUTPUT
+
+  run_matrix:
+    name: '${{ matrix.package }} (linux-alma9)'
+    needs: configure_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.configure_matrix.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    container:
+      image: condaforge/linux-anvil-alma-aarch64:9
+    steps:
+      - name: get environment path
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ inputs.solved-environment-key }}-*
+          path: ${{ env.solved_environment_path }}
+          merge-multiple: true
+
+      - name: 'Fetch base channel with patches'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - name: 'Fetch rebuilt channel'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: ${{ env.rebuilt_channel_path }}
+
+      - name: Maximize build space for linux
+        shell: bash
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          echo "Removing unwanted software... "
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "... done"
+
+      - name: install environment
+        id: env
+        uses: qiime2/action-library-packaging/create-env@beta
+        with:
+          conda-prefix: './test-env'
+          environment-file: ${{ env.solved_environment_path }}/${{ inputs.distro-name }}-linux-alma9-conda.yml
+
+      - name: run qiime info
+        shell: bash
+        run: |
+          ${{ steps.env.outputs.conda-activate }}
+          qiime info
+
+      - name: 'collect package path'
+        id: 'collect-package'
+        uses: qiime2/action-library-packaging/collect-package@beta
+        with:
+          runner: ubuntu-latest
+          package: ${{ matrix.package }}
+          channels: '["${{ env.rebuilt_channel_path }}", "${{ env.patched_channel_path }}"]'
+
+      - name: 'run tests'
+        uses: qiime2/action-library-packaging/test-package@beta
+        with:
+          conda-activate: ${{ steps.env.outputs.conda-activate }}
+          package-path: ${{ steps.collect-package.outputs.path }}

--- a/.github/workflows/ci-distro-trial_3-test-metapackage-osx.yaml
+++ b/.github/workflows/ci-distro-trial_3-test-metapackage-osx.yaml
@@ -1,0 +1,108 @@
+on:
+  workflow_call:
+    inputs:
+      solved-environment-key:
+        required: true
+        type: string
+      matrix-key:
+        required: true
+        type: string
+      rebuilt-channel-key:
+        required: true
+        type: string
+      patched-channel-key:
+        required: true
+        type: string
+      distro-name:
+        required: true
+        type: string
+
+env:
+  matrix_path: './matrix'
+  solved_environment_path: './env-file'
+  patched_channel_path: './patched-channel'
+  rebuilt_channel_path: './rebuilt-channel'
+
+jobs:
+  configure_matrix:
+    name: 'Set up build matrix'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.matrix-key }}
+          path: '${{ env.matrix_path }}'
+
+      - id: set-matrix
+        run: |
+          echo "matrix=$(cat ${{ env.matrix_path }}/retest_matrix.json)" >> $GITHUB_OUTPUT
+
+  run_matrix:
+    name: '${{ matrix.package }} (macos-15-intel)'
+    needs: configure_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.configure_matrix.outputs.matrix) }}
+    runs-on: macos-15-intel
+    steps:
+      - name: get environment path
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ inputs.solved-environment-key }}-*
+          path: ${{ env.solved_environment_path }}
+          merge-multiple: true
+
+      - name: 'Fetch base channel with patches'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.patched-channel-key }}
+          path: ${{ env.patched_channel_path }}
+
+      - name: 'Fetch rebuilt channel'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.rebuilt-channel-key }}
+          path: ${{ env.rebuilt_channel_path }}
+
+      - name: Maximize build space for linux
+        shell: bash
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          echo "Removing unwanted software... "
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "... done"
+
+      - name: install environment
+        id: env
+        uses: qiime2/action-library-packaging/create-env@beta
+        with:
+          conda-prefix: './test-env'
+          environment-file: ${{ env.solved_environment_path }}/${{ inputs.distro-name }}-macos-15-intel-conda.yml
+
+      - name: run qiime info
+        shell: bash
+        run: |
+          ${{ steps.env.outputs.conda-activate }}
+          qiime info
+
+      - name: 'collect package path'
+        id: 'collect-package'
+        uses: qiime2/action-library-packaging/collect-package@beta
+        with:
+          runner: macos-15-intel
+          package: ${{ matrix.package }}
+          channels: '["${{ env.rebuilt_channel_path }}", "${{ env.patched_channel_path }}"]'
+
+      - name: 'run tests'
+        uses: qiime2/action-library-packaging/test-package@beta
+        with:
+          conda-activate: ${{ steps.env.outputs.conda-activate }}
+          package-path: ${{ steps.collect-package.outputs.path }}

--- a/.github/workflows/create-prepare-pr-linux.yaml
+++ b/.github/workflows/create-prepare-pr-linux.yaml
@@ -1,0 +1,164 @@
+# TODO: consolidate to a single workflow with os as input
+name: create-prepare-pr-linux
+on:
+  workflow_call:
+    inputs:
+      distro:
+        required: true
+        type: string
+      draft:
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      distro:
+        required: true
+        type: string
+      draft:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.pr.outputs.pull-request-head-sha }}
+      pr: ${{ steps.pr.outputs.pull-request-number }}
+      epoch: ${{ steps.vars.outputs.epoch }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "get distro info"
+        id: yaml
+        uses: qiime2/distributions/.github/actions/read-yaml@dev
+        with:
+          file: data.yaml
+
+      - name: set epoch and date
+        id: vars
+        shell: bash
+        run: |
+          echo epoch=${{ fromJSON(steps.yaml.outputs.data).active_epoch }} >> $GITHUB_OUTPUT
+          echo today=$(date +'%Y-%m-%d') >> $GITHUB_OUTPUT
+
+      - name: modify file
+        shell: bash
+        run: |
+          echo '# modified: ${{ steps.vars.outputs.today }}' >> '${{ steps.vars.outputs.epoch }}/${{ inputs.distro }}/passed/seed-environment-conda.yml'
+
+      - name: Create Pull Request
+        id: pr
+        # Replaces qiime2/create-pull-request@v5
+        # (previously forked from peter-evans/create-pull-request)
+        uses: qiime2-cutlery/create-pull-request@v5
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          branch: Prepare-${{ steps.vars.outputs.epoch }}/${{ inputs.distro }}/${{ steps.vars.outputs.today }}
+          draft: ${{ inputs.draft }}
+          title: "[${{ inputs.distro }}] Automated Trial (Prepare)"
+          body: |
+            Automated updates from `create-prepare-pr.yaml`
+            triggered by ${{ github.event_name }}.
+          author: "q2d2 <q2d2.noreply@gmail.com>"
+          committer: "q2d2 <q2d2.noreply@gmail.com>"
+          commit-message: |
+            Automated updates to seed environment: ${{ inputs.distro }}
+
+  await-workflow:
+    needs: [create-pr]
+    runs-on: ubuntu-latest
+    outputs:
+      gh-response: ${{ steps.merge-trial.outputs.gh-response }}
+    steps:
+      - name: get workflow id
+        id: get-id
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 30  # let the workflow start
+          echo run-id=$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/qiime2/distributions/actions/runs?head_sha=${{ needs.create-pr.outputs.sha }} \
+              -q '.workflow_runs[] | select(.name == "ci-distro-trial-linux").id' | head -n 1
+          ) >> $GITHUB_OUTPUT
+
+      - name: await workflow id ${{ steps.get-id.outputs.run-id }}
+        # Forked from Codex-/await-remote-run@v1.0.0
+        uses: qiime2-cutlery/await-remote-run@v1.0.0
+        with:
+          token: ${{ github.token }}
+          repo: distributions
+          owner: qiime2
+          run_id: ${{ steps.get-id.outputs.run-id }}
+          run_timeout_seconds: 21600
+          poll_interval_ms: 45000
+
+      - name: merge trial
+        id: merge-trial
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          GH_RESPONSE=$(
+            gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/qiime2/distributions/pulls/${{ needs.create-pr.outputs.pr }}/merge
+          )
+
+          echo "gh-response=$GH_RESPONSE" >> $GITHUB_OUTPUT
+
+  update-latest-envs:
+    needs: [create-pr, await-workflow]
+    runs-on: ubuntu-latest
+    outputs:
+      env-pr: ${{ steps.env-updates-pr.outputs.pull-request-number }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: copy updated env file from merged prepare pr
+        id: copy-env
+        if: contains(${{ needs.await-workflow.outputs.gh-response }}, 'merged:true')
+        run: |
+          cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-macos-latest-conda.yml' './latest/passed/'
+          cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-ubuntu-latest-conda.yml' './latest/passed/'
+
+      - name: Open Pull Request to update latest env files
+        id: env-updates-pr
+        # Replaces qiime2/create-pull-request@v5
+        # (previously forked from peter-evans/create-pull-request)
+        uses: qiime2-cutlery/create-pull-request@v5
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          branch: update-latest-envs-from-PR-${{ needs.create-pr.outputs.pr }}
+          title: "[${{ inputs.distro }}] latest env updates from PR ${{ needs.create-pr.outputs.pr }}"
+          add-paths: ./latest/passed/
+          body: |
+            Automated updates to latest env files from `create-prepare-pr.yaml`
+            triggered by ${{ github.event_name }}.
+          author: "q2d2 <q2d2.noreply@gmail.com>"
+          committer: "q2d2 <q2d2.noreply@gmail.com>"
+          commit-message: |
+            Automated updates to latest resolved environment files: ${{ needs.create-pr.outputs.epoch }} ${{ inputs.distro }}
+
+  merge-latest-env-pr:
+    needs: [update-latest-envs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: merge env updates
+        id: merge-env-pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/qiime2/distributions/pulls/${{ needs.update-latest-envs.outputs.env-pr }}/merge

--- a/.github/workflows/create-prepare-pr-osx.yaml
+++ b/.github/workflows/create-prepare-pr-osx.yaml
@@ -1,0 +1,164 @@
+# TODO: consolidate to a single workflow with os as input
+name: create-prepare-pr-osx
+on:
+  workflow_call:
+    inputs:
+      distro:
+        required: true
+        type: string
+      draft:
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      distro:
+        required: true
+        type: string
+      draft:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.pr.outputs.pull-request-head-sha }}
+      pr: ${{ steps.pr.outputs.pull-request-number }}
+      epoch: ${{ steps.vars.outputs.epoch }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "get distro info"
+        id: yaml
+        uses: qiime2/distributions/.github/actions/read-yaml@dev
+        with:
+          file: data.yaml
+
+      - name: set epoch and date
+        id: vars
+        shell: bash
+        run: |
+          echo epoch=${{ fromJSON(steps.yaml.outputs.data).active_epoch }} >> $GITHUB_OUTPUT
+          echo today=$(date +'%Y-%m-%d') >> $GITHUB_OUTPUT
+
+      - name: modify file
+        shell: bash
+        run: |
+          echo '# modified: ${{ steps.vars.outputs.today }}' >> '${{ steps.vars.outputs.epoch }}/${{ inputs.distro }}/passed/seed-environment-conda.yml'
+
+      - name: Create Pull Request
+        id: pr
+        # Replaces qiime2/create-pull-request@v5
+        # (previously forked from peter-evans/create-pull-request)
+        uses: qiime2-cutlery/create-pull-request@v5
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          branch: Prepare-${{ steps.vars.outputs.epoch }}/${{ inputs.distro }}/${{ steps.vars.outputs.today }}
+          draft: ${{ inputs.draft }}
+          title: "[${{ inputs.distro }}] Automated Trial (Prepare)"
+          body: |
+            Automated updates from `create-prepare-pr.yaml`
+            triggered by ${{ github.event_name }}.
+          author: "q2d2 <q2d2.noreply@gmail.com>"
+          committer: "q2d2 <q2d2.noreply@gmail.com>"
+          commit-message: |
+            Automated updates to seed environment: ${{ inputs.distro }}
+
+  await-workflow:
+    needs: [create-pr]
+    runs-on: ubuntu-latest
+    outputs:
+      gh-response: ${{ steps.merge-trial.outputs.gh-response }}
+    steps:
+      - name: get workflow id
+        id: get-id
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 30  # let the workflow start
+          echo run-id=$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/qiime2/distributions/actions/runs?head_sha=${{ needs.create-pr.outputs.sha }} \
+              -q '.workflow_runs[] | select(.name == "ci-distro-trial-osx").id' | head -n 1
+          ) >> $GITHUB_OUTPUT
+
+      - name: await workflow id ${{ steps.get-id.outputs.run-id }}
+        # Forked from Codex-/await-remote-run@v1.0.0
+        uses: qiime2-cutlery/await-remote-run@v1.0.0
+        with:
+          token: ${{ github.token }}
+          repo: distributions
+          owner: qiime2
+          run_id: ${{ steps.get-id.outputs.run-id }}
+          run_timeout_seconds: 21600
+          poll_interval_ms: 45000
+
+      - name: merge trial
+        id: merge-trial
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          GH_RESPONSE=$(
+            gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/qiime2/distributions/pulls/${{ needs.create-pr.outputs.pr }}/merge
+          )
+
+          echo "gh-response=$GH_RESPONSE" >> $GITHUB_OUTPUT
+
+  update-latest-envs:
+    needs: [create-pr, await-workflow]
+    runs-on: ubuntu-latest
+    outputs:
+      env-pr: ${{ steps.env-updates-pr.outputs.pull-request-number }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: copy updated env file from merged prepare pr
+        id: copy-env
+        if: contains(${{ needs.await-workflow.outputs.gh-response }}, 'merged:true')
+        run: |
+          cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-macos-latest-conda.yml' './latest/passed/'
+          cp '${{ needs.create-pr.outputs.epoch }}/${{ inputs.distro }}/passed/qiime2-${{ inputs.distro }}-ubuntu-latest-conda.yml' './latest/passed/'
+
+      - name: Open Pull Request to update latest env files
+        id: env-updates-pr
+        # Replaces qiime2/create-pull-request@v5
+        # (previously forked from peter-evans/create-pull-request)
+        uses: qiime2-cutlery/create-pull-request@v5
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          branch: update-latest-envs-from-PR-${{ needs.create-pr.outputs.pr }}
+          title: "[${{ inputs.distro }}] latest env updates from PR ${{ needs.create-pr.outputs.pr }}"
+          add-paths: ./latest/passed/
+          body: |
+            Automated updates to latest env files from `create-prepare-pr.yaml`
+            triggered by ${{ github.event_name }}.
+          author: "q2d2 <q2d2.noreply@gmail.com>"
+          committer: "q2d2 <q2d2.noreply@gmail.com>"
+          commit-message: |
+            Automated updates to latest resolved environment files: ${{ needs.create-pr.outputs.epoch }} ${{ inputs.distro }}
+
+  merge-latest-env-pr:
+    needs: [update-latest-envs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: merge env updates
+        id: merge-env-pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/qiime2/distributions/pulls/${{ needs.update-latest-envs.outputs.env-pr }}/merge

--- a/.github/workflows/cron-prepare-linux.yaml
+++ b/.github/workflows/cron-prepare-linux.yaml
@@ -1,0 +1,34 @@
+# TODO: consolidate to a single workflow with os as input
+name: cron-prepare-linux
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 0 * * SUN
+
+jobs:
+  tiny:
+    uses: ./.github/workflows/create-prepare-pr-linux.yaml
+    secrets: inherit
+    with:
+      distro: tiny
+
+  amplicon:
+    needs: [tiny]
+    uses: ./.github/workflows/create-prepare-pr-linux.yaml
+    secrets: inherit
+    with:
+      distro: amplicon
+
+  moshpit:
+    needs: [tiny, amplicon]
+    uses: ./.github/workflows/create-prepare-pr-linux.yaml
+    secrets: inherit
+    with:
+      distro: moshpit
+
+  pathogenome:
+    needs: [tiny, amplicon, moshpit]
+    uses: ./.github/workflows/create-prepare-pr-linux.yaml
+    secrets: inherit
+    with:
+      distro: pathogenome

--- a/.github/workflows/cron-prepare-osx.yaml
+++ b/.github/workflows/cron-prepare-osx.yaml
@@ -1,0 +1,34 @@
+# TODO: consolidate to a single workflow with os as input
+name: cron-prepare-osx
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 0 * * SUN
+
+jobs:
+  tiny:
+    uses: ./.github/workflows/create-prepare-pr-osx.yaml
+    secrets: inherit
+    with:
+      distro: tiny
+
+  amplicon:
+    needs: [tiny]
+    uses: ./.github/workflows/create-prepare-pr-osx.yaml
+    secrets: inherit
+    with:
+      distro: amplicon
+
+  moshpit:
+    needs: [tiny, amplicon]
+    uses: ./.github/workflows/create-prepare-pr-osx.yaml
+    secrets: inherit
+    with:
+      distro: moshpit
+
+  pathogenome:
+    needs: [tiny, amplicon, moshpit]
+    uses: ./.github/workflows/create-prepare-pr-osx.yaml
+    secrets: inherit
+    with:
+      distro: pathogenome

--- a/.github/workflows/lib-ci-dev-linux.yaml
+++ b/.github/workflows/lib-ci-dev-linux.yaml
@@ -1,0 +1,183 @@
+# # Example of workflow trigger for calling workflow (the client).
+# name: ci-dev
+# on:
+#   pull_request:
+#     branches: ["dev"]
+#   push:
+#     branches: ["dev"]
+# jobs:
+#   ci:
+#     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
+#     with:
+#       distro: core
+
+on:
+  workflow_call:
+    inputs:
+      distro:
+        description: "Distro to test with"
+        type: string
+        required: true
+
+      recipe-path:
+        description: "Path to recipe"
+        type: string
+        required: false
+        default: 'conda-recipe/'
+
+      additional-reports-path:
+        description: "Path of additional reports to store in GH artifact"
+        type: string
+        required: false
+        default: ''
+
+      additional-reports-name:
+        description: "Name of GH artifact for additional reports"
+        type: string
+        required: false
+        default: 'reports'
+
+    outputs:
+      additional-reports-path:
+        value: ${{ inputs.additional-reports-path }}
+      additional-reports-name:
+        value: ${{ inputs.additional-reports-name }}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      active-epoch: ${{ fromJSON(steps.yaml.outputs.data).active_epoch }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: qiime2/distributions
+          sparse-checkout: |
+            data.yaml
+      - name: "get distro info"
+        id: yaml
+        uses: qiime2/distributions/.github/actions/read-yaml@dev
+        with:
+          file: data.yaml
+
+  build-and-test:
+    name: '${{ github.event.repository.name }} (linux-alma9)'
+    needs: setup
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image: condaforge/linux-anvil-alma-aarch64:9
+    env:
+      plugin_path: ./repo
+      built_channel_path: ./built-channel
+      epoch: ${{ needs.setup.outputs.active-epoch }}
+      seed_env_path: ${{ needs.setup.outputs.active-epoch }}/${{ inputs.distro }}/staged/seed-environment-conda.yml
+      env_prefix: ./test-env
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout-repo
+        with:
+          path: ${{ env.plugin_path }}
+          fetch-depth: 0
+          submodules: true
+
+      - uses: actions/checkout@v3
+        with:
+          repository: qiime2/distributions
+          path: ./distro
+          sparse-checkout: ${{ env.seed_env_path }}
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - name: 'Set up test environment'
+        run: |
+          conda create -y -p ${{ env.env_prefix }}
+          mkdir -p ${{ env.env_prefix }}/etc
+          cat <<EOF > '${{ env.env_prefix }}/etc/activate.sh'
+            . "$CONDA/etc/profile.d/conda.sh"
+            conda activate '${{ env.env_prefix }}'
+          EOF
+          chmod +x '${{ env.env_prefix }}/etc/activate.sh'
+
+      - name: 'Set up built channel'
+        run: |
+          ${{ steps.setup-conda.outputs.conda-activate }}
+          mkdir -p ${{ env.built_channel_path }}
+          python -m conda_index ${{ env.built_channel_path }}
+
+      - uses: qiime2/action-library-packaging/make-conda-config@beta
+        name: 'Create conda build config'
+        id: make-cbc
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          seed-environment: ./distro/${{ env.seed_env_path }}
+          conda-build-config: 'conda_build_config.yml'
+          channels: '["${{ env.built_channel_path }}"]'
+
+      - uses: qiime2/action-library-packaging/build-package@beta
+        name: 'Build ${{ github.event.repository.name }}'
+        id: build-package
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          recipe-path: ${{ env.plugin_path }}/${{ inputs.recipe-path }}
+          conda-build-config: ${{ steps.make-cbc.outputs.conda-build-config }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+          output-channel: ${{ env.built_channel_path }}
+
+      - uses: qiime2/action-library-packaging/install-package@beta
+        name: 'Install ${{ github.event.repository.name }}'
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          package-name: ${{ steps.build-package.outputs.package-name }}
+          package-version: ${{ steps.build-package.outputs.package-version }}
+          conda-prefix: ${{ env.env_prefix }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+
+      - name: 'set up yaml for test env'
+        shell: bash
+        run: |
+          source ${{ env.env_prefix }}/etc/activate.sh
+          conda activate '${{ env.env_prefix }}'
+          pip install pyyaml
+
+      - uses: qiime2/action-library-packaging/test-package@beta
+        name: 'Test ${{ github.event.repository.name }}'
+        with:
+          conda-activate: source ${{ env.env_prefix }}/etc/activate.sh
+          package-path: ${{ env.built_channel_path }}/${{ steps.build-package.outputs.conda-subdir }}/${{ steps.build-package.outputs.package-filename }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.additional-reports-path != '' }}
+        name: 'Upload additional reports: ${{ inputs.additional-reports-name }}'
+        with:
+          name: ${{ inputs.additional-reports-name }}
+          path: ${{ inputs.additional-reports-path }}
+          overwrite: true
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout source
+      uses: actions/checkout@v3
+
+    - name: set up python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -q toml
+        pip install -q https://github.com/qiime2/q2lint/archive/master.zip
+        pip install -q flake8
+
+    - name: run flake8
+      run: flake8
+
+    - name: run q2lint
+      run: q2lint

--- a/.github/workflows/lib-ci-dev-osx.yaml
+++ b/.github/workflows/lib-ci-dev-osx.yaml
@@ -1,0 +1,173 @@
+# # Example of workflow trigger for calling workflow (the client).
+# name: ci-dev
+# on:
+#   pull_request:
+#     branches: ["dev"]
+#   push:
+#     branches: ["dev"]
+# jobs:
+#   ci:
+#     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
+#     with:
+#       distro: core
+
+on:
+  workflow_call:
+    inputs:
+      distro:
+        description: "Distro to test with"
+        type: string
+        required: true
+
+      recipe-path:
+        description: "Path to recipe"
+        type: string
+        required: false
+        default: 'conda-recipe/'
+
+      additional-reports-path:
+        description: "Path of additional reports to store in GH artifact"
+        type: string
+        required: false
+        default: ''
+
+      additional-reports-name:
+        description: "Name of GH artifact for additional reports"
+        type: string
+        required: false
+        default: 'reports'
+
+    outputs:
+      additional-reports-path:
+        value: ${{ inputs.additional-reports-path }}
+      additional-reports-name:
+        value: ${{ inputs.additional-reports-name }}
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      active-epoch: ${{ fromJSON(steps.yaml.outputs.data).active_epoch }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: qiime2/distributions
+          sparse-checkout: |
+            data.yaml
+      - name: "get distro info"
+        id: yaml
+        uses: qiime2/distributions/.github/actions/read-yaml@dev
+        with:
+          file: data.yaml
+
+  build-and-test:
+    name: '${{ github.event.repository.name }} (macos-15-intel)'
+    needs: setup
+    strategy:
+      fail-fast: false
+    runs-on: macos-15-intel
+    env:
+      plugin_path: ./repo
+      built_channel_path: ./built-channel
+      epoch: ${{ needs.setup.outputs.active-epoch }}
+      seed_env_path: ${{ needs.setup.outputs.active-epoch }}/${{ inputs.distro }}/staged/seed-environment-conda.yml
+      env_prefix: ./test-env
+    steps:
+      - uses: actions/checkout@v4
+        id: checkout-repo
+        with:
+          path: ${{ env.plugin_path }}
+          fetch-depth: 0
+          submodules: true
+
+      - uses: actions/checkout@v3
+        with:
+          repository: qiime2/distributions
+          path: ./distro
+          sparse-checkout: ${{ env.seed_env_path }}
+
+      - uses: qiime2/action-library-packaging/environment@beta
+        name: 'Set up build environment'
+        id: setup-conda
+
+      - name: 'Set up test environment'
+        run: |
+          conda create -y -p ${{ env.env_prefix }}
+          mkdir -p ${{ env.env_prefix }}/etc
+          cat <<EOF > '${{ env.env_prefix }}/etc/activate.sh'
+            . "$CONDA/etc/profile.d/conda.sh"
+            conda activate '${{ env.env_prefix }}'
+          EOF
+          chmod +x '${{ env.env_prefix }}/etc/activate.sh'
+
+      - name: 'Set up built channel'
+        run: |
+          ${{ steps.setup-conda.outputs.conda-activate }}
+          mkdir -p ${{ env.built_channel_path }}
+          python -m conda_index ${{ env.built_channel_path }}
+
+      - uses: qiime2/action-library-packaging/make-conda-config@beta
+        name: 'Create conda build config'
+        id: make-cbc
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          seed-environment: ./distro/${{ env.seed_env_path }}
+          conda-build-config: 'conda_build_config.yml'
+          channels: '["${{ env.built_channel_path }}"]'
+
+      - uses: qiime2/action-library-packaging/build-package@beta
+        name: 'Build ${{ github.event.repository.name }}'
+        id: build-package
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          recipe-path: ${{ env.plugin_path }}/${{ inputs.recipe-path }}
+          conda-build-config: ${{ steps.make-cbc.outputs.conda-build-config }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+          output-channel: ${{ env.built_channel_path }}
+
+      - uses: qiime2/action-library-packaging/install-package@beta
+        name: 'Install ${{ github.event.repository.name }}'
+        with:
+          conda-activate: ${{ steps.setup-conda.outputs.conda-activate }}
+          package-name: ${{ steps.build-package.outputs.package-name }}
+          package-version: ${{ steps.build-package.outputs.package-version }}
+          conda-prefix: ${{ env.env_prefix }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+
+      - name: 'set up yaml for test env'
+        shell: bash
+        run: |
+          source ${{ env.env_prefix }}/etc/activate.sh
+          conda activate '${{ env.env_prefix }}'
+          pip install pyyaml
+
+      - uses: qiime2/action-library-packaging/test-package@beta
+        name: 'Test ${{ github.event.repository.name }}'
+        with:
+          conda-activate: source ${{ env.env_prefix }}/etc/activate.sh
+          package-path: ${{ env.built_channel_path }}/${{ steps.build-package.outputs.conda-subdir }}/${{ steps.build-package.outputs.package-filename }}
+          channels: ${{ steps.make-cbc.outputs.channels }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout source
+      uses: actions/checkout@v3
+
+    - name: set up python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -q toml
+        pip install -q https://github.com/qiime2/q2lint/archive/master.zip
+        pip install -q flake8
+
+    - name: run flake8
+      run: flake8
+
+    - name: run q2lint
+      run: q2lint


### PR DESCRIPTION
opening a PR for posterity but going to merge so that i can actually test this.

this creates 'parallel universes' for our workflows, split by operating system. the linux builds now utilize a docker container for all actions (ref (here)[https://hub.docker.com/r/condaforge/linux-anvil-alma-aarch64]).

if this works, i'll do some consolidation to our cron prepare & create prepare PR workflows to template out the OS.