### PR TITLE
Dockerfile updates for qiime2->rachis

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -21,7 +21,7 @@ RUN conda env create -n rachis-${DISTRO}-${EPOCH} --file released-env.yml \
  && rm released-env.yml
 
 RUN /bin/bash -c "source activate rachis-${DISTRO}-${EPOCH}"
-ENV CONDA_PREFIX /opt/conda/envs/qiime2-${DISTRO}-${EPOCH}/
+ENV CONDA_PREFIX /opt/conda/envs/rachis-${DISTRO}-${EPOCH}/
 RUN qiime dev refresh-cache
 RUN python -c "from qiime2.sdk.parallel_config import get_vendored_config; get_vendored_config()"
 RUN echo "source activate qiime2-${DISTRO}-${EPOCH}" >> /root/.bashrc

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -4,7 +4,7 @@ ARG EPOCH
 ARG DISTRO
 ARG STATUS=released
 
-ENV PATH /opt/conda/envs/qiime2-${DISTRO}-${EPOCH}/bin:$PATH
+ENV PATH /opt/conda/envs/rachis-${DISTRO}-${EPOCH}/bin:$PATH
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 ENV MPLBACKEND agg

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,7 +14,7 @@ RUN conda update -q -y conda
 RUN conda install -q -y wget
 RUN apt-get install -y procps
 
-COPY ${EPOCH}/${DISTRO}/${STATUS}/rachis-${DISTRO}-linux-64-conda.yml released-env.yml
+COPY ${EPOCH}/${DISTRO}/${DISTRO_SUBDIR}/rachis-${DISTRO}-linux-64-conda.yml released-env.yml
 RUN conda env create -n rachis-${DISTRO}-${EPOCH} --file released-env.yml \
  && conda clean -a -y \
  && chmod -R a+rwx /opt/conda \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3:latest
 
 ARG EPOCH
 ARG DISTRO
-ARG STATUS=released
+ARG DISTRO_SUBDIR=released
 
 ENV PATH /opt/conda/envs/rachis-${DISTRO}-${EPOCH}/bin:$PATH
 ENV LC_ALL C.UTF-8

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,7 +15,7 @@ RUN conda install -q -y wget
 RUN apt-get install -y procps
 
 COPY ${EPOCH}/${DISTRO}/${STATUS}/rachis-${DISTRO}-linux-64-conda.yml released-env.yml
-RUN conda env create -n qiime2-${DISTRO}-${EPOCH} --file released-env.yml \
+RUN conda env create -n rachis-${DISTRO}-${EPOCH} --file released-env.yml \
  && conda clean -a -y \
  && chmod -R a+rwx /opt/conda \
  && rm released-env.yml

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -24,7 +24,7 @@ RUN /bin/bash -c "source activate rachis-${DISTRO}-${EPOCH}"
 ENV CONDA_PREFIX /opt/conda/envs/rachis-${DISTRO}-${EPOCH}/
 RUN qiime dev refresh-cache
 RUN python -c "from qiime2.sdk.parallel_config import get_vendored_config; get_vendored_config()"
-RUN echo "source activate qiime2-${DISTRO}-${EPOCH}" >> /root/.bashrc
+RUN echo "source activate rachis-${DISTRO}-${EPOCH}" >> /root/.bashrc
 RUN echo "source tab-qiime" >> /root/.bashrc
 
 # HACK: regression in libc 2.41 causes:

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,6 +2,7 @@ FROM continuumio/miniconda3:latest
 
 ARG EPOCH
 ARG DISTRO
+ARG STATUS=released
 
 ENV PATH /opt/conda/envs/qiime2-${DISTRO}-${EPOCH}/bin:$PATH
 ENV LC_ALL C.UTF-8
@@ -13,7 +14,7 @@ RUN conda update -q -y conda
 RUN conda install -q -y wget
 RUN apt-get install -y procps
 
-COPY ${EPOCH}/${DISTRO}/released/qiime2-${DISTRO}-linux-64-conda.yml released-env.yml
+COPY ${EPOCH}/${DISTRO}/${STATUS}/rachis-${DISTRO}-linux-64-conda.yml released-env.yml
 RUN conda env create -n qiime2-${DISTRO}-${EPOCH} --file released-env.yml \
  && conda clean -a -y \
  && chmod -R a+rwx /opt/conda \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -20,7 +20,7 @@ RUN conda env create -n rachis-${DISTRO}-${EPOCH} --file released-env.yml \
  && chmod -R a+rwx /opt/conda \
  && rm released-env.yml
 
-RUN /bin/bash -c "source activate qiime2-${DISTRO}-${EPOCH}"
+RUN /bin/bash -c "source activate rachis-${DISTRO}-${EPOCH}"
 ENV CONDA_PREFIX /opt/conda/envs/qiime2-${DISTRO}-${EPOCH}/
 RUN qiime dev refresh-cache
 RUN python -c "from qiime2.sdk.parallel_config import get_vendored_config; get_vendored_config()"


### PR DESCRIPTION
Also adds another arg for where to look for the env file (passed/released/staged); this is useful for testing the Dockerfile during dev cycles when a `release/` directory doesn't exist yet. (I couldn't think of a better name than `status`.) @lizgehret let me know if you think is useful or if there's a better name. Also, do we care about the fact that we won't be able to build older releases with this Dockerfile anymore due to the rachis name change?