### PR TITLE
[tiny] latest env updates from PR 1378

### DIFF
--- a/latest/passed/rachis-tiny-osx-arm64-conda.yml
+++ b/latest/passed/rachis-tiny-osx-arm64-conda.yml
@@ -199,7 +199,7 @@ dependencies:
 - r-rlang=1.2.0
 - r-rprojroot=2.1.1
 - r-withr=3.0.2
-- rachis=2026.7.0.dev0+3.g68cda6d
+- rachis=2026.7.0.dev0+4.gd6cfc47
 - readline=8.3
 - referencing=0.37.0
 - requests=2.33.1


### PR DESCRIPTION
Automated updates to latest env files from `create-prepare-pr-platform.yaml` for `osx-arm64`
triggered by schedule.