### PR TITLE
REL: rebuild 2026.4.1 (pathogenome)

### DIFF
--- a/2026.4/pathogenome/passed/rachis-pathogenome-linux-64-conda.yml
+++ b/2026.4/pathogenome/passed/rachis-pathogenome-linux-64-conda.yml
@@ -49,7 +49,7 @@ dependencies:
 - bz2file=0.98
 - bzip2=1.0.8
 - c-ares=1.34.6
-- ca-certificates=2026.4.22
+- ca-certificates=2026.5.20
 - cached-property=1.5.2
 - cached_property=1.5.2
 - cairo=1.18.4
@@ -57,7 +57,7 @@ dependencies:
 - cffi=2.0.0
 - chardet=7.4.3
 - charset-normalizer=3.4.7
-- checkv=1.1.0
+- checkv=1.1.1
 - click=8.1.8
 - colorama=0.4.6
 - comm=0.2.3
@@ -83,7 +83,7 @@ dependencies:
 - font-ttf-inconsolata=3.000
 - font-ttf-source-code-pro=2.038
 - font-ttf-ubuntu=0.83
-- fontconfig=2.17.1
+- fontconfig=2.18.0
 - fonts-conda-ecosystem=1
 - fonts-conda-forge=1
 - fonttools=4.63.0
@@ -114,9 +114,9 @@ dependencies:
 - humanize=4.15.0
 - hyperframe=6.1.0
 - icu=75.1
-- idna=3.13
+- idna=3.15
 - ijson=3.5.0
-- importlib-metadata=8.8.0
+- importlib-metadata=9.0.0
 - iniconfig=2.3.0
 - iow=1.0.8
 - ipython=9.13.0
@@ -266,7 +266,7 @@ dependencies:
 - patsy=1.0.2
 - pcre2=10.46
 - perl=5.32.1
-- perl-archive-tar=3.06
+- perl-archive-tar=3.08
 - perl-carp=1.50
 - perl-common-sense=3.75
 - perl-compress-raw-bzip2=2.214
@@ -293,7 +293,6 @@ dependencies:
 - pixman=0.46.4
 - pluggy=1.6.0
 - prodigal=2.6.3
-- prodigal-gv=2.11.0
 - prompt-toolkit=3.0.52
 - protobuf=5.28.3
 - psutil=7.2.2
@@ -303,7 +302,7 @@ dependencies:
 - py-xgboost=3.2.0
 - pyarrow=16.1.0
 - pyarrow-core=16.1.0
-- pycparser=2.22
+- pycparser=3.0
 - pydantic=2.13.4
 - pydantic-core=2.46.4
 - pygments=2.20.0
@@ -401,7 +400,7 @@ dependencies:
 - tqdm=4.67.3
 - traitlets=5.15.0
 - typeguard=4.5.2
-- typer=0.23.1
+- typer=0.26.0
 - typing-extensions=4.15.0
 - typing-inspection=0.4.2
 - typing_extensions=4.15.0
@@ -419,7 +418,7 @@ dependencies:
 - wget=1.21.4
 - wheel=0.47.0
 - widgetsnbextension=4.0.15
-- wrapt=2.1.2
+- wrapt=2.2.1
 - xcb-util=0.4.1
 - xcb-util-cursor=0.1.6
 - xcb-util-image=0.4.0

--- a/2026.4/pathogenome/released/rachis-pathogenome-linux-64-conda.yml
+++ b/2026.4/pathogenome/released/rachis-pathogenome-linux-64-conda.yml
@@ -49,7 +49,7 @@ dependencies:
 - bz2file=0.98
 - bzip2=1.0.8
 - c-ares=1.34.6
-- ca-certificates=2026.4.22
+- ca-certificates=2026.5.20
 - cached-property=1.5.2
 - cached_property=1.5.2
 - cairo=1.18.4
@@ -57,7 +57,7 @@ dependencies:
 - cffi=2.0.0
 - chardet=7.4.3
 - charset-normalizer=3.4.7
-- checkv=1.1.0
+- checkv=1.1.1
 - click=8.1.8
 - colorama=0.4.6
 - comm=0.2.3
@@ -83,7 +83,7 @@ dependencies:
 - font-ttf-inconsolata=3.000
 - font-ttf-source-code-pro=2.038
 - font-ttf-ubuntu=0.83
-- fontconfig=2.17.1
+- fontconfig=2.18.0
 - fonts-conda-ecosystem=1
 - fonts-conda-forge=1
 - fonttools=4.63.0
@@ -114,9 +114,9 @@ dependencies:
 - humanize=4.15.0
 - hyperframe=6.1.0
 - icu=75.1
-- idna=3.13
+- idna=3.15
 - ijson=3.5.0
-- importlib-metadata=8.8.0
+- importlib-metadata=9.0.0
 - iniconfig=2.3.0
 - iow=1.0.8
 - ipython=9.13.0
@@ -266,7 +266,7 @@ dependencies:
 - patsy=1.0.2
 - pcre2=10.46
 - perl=5.32.1
-- perl-archive-tar=3.06
+- perl-archive-tar=3.08
 - perl-carp=1.50
 - perl-common-sense=3.75
 - perl-compress-raw-bzip2=2.214
@@ -293,7 +293,6 @@ dependencies:
 - pixman=0.46.4
 - pluggy=1.6.0
 - prodigal=2.6.3
-- prodigal-gv=2.11.0
 - prompt-toolkit=3.0.52
 - protobuf=5.28.3
 - psutil=7.2.2
@@ -303,7 +302,7 @@ dependencies:
 - py-xgboost=3.2.0
 - pyarrow=16.1.0
 - pyarrow-core=16.1.0
-- pycparser=2.22
+- pycparser=3.0
 - pydantic=2.13.4
 - pydantic-core=2.46.4
 - pygments=2.20.0
@@ -401,7 +400,7 @@ dependencies:
 - tqdm=4.67.3
 - traitlets=5.15.0
 - typeguard=4.5.2
-- typer=0.23.1
+- typer=0.26.0
 - typing-extensions=4.15.0
 - typing-inspection=0.4.2
 - typing_extensions=4.15.0
@@ -419,7 +418,7 @@ dependencies:
 - wget=1.21.4
 - wheel=0.47.0
 - widgetsnbextension=4.0.15
-- wrapt=2.1.2
+- wrapt=2.2.1
 - xcb-util=0.4.1
 - xcb-util-cursor=0.1.6
 - xcb-util-image=0.4.0

--- a/2026.4/pathogenome/released/seed-environment-conda-linux.yml
+++ b/2026.4/pathogenome/released/seed-environment-conda-linux.yml
@@ -1,4 +1,3 @@
-# trigger a new build
 channels:
 - https://packages.qiime2.org/qiime2/2026.4/pathogenome/released
 - conda-forge

--- a/2026.4/pathogenome/released/seed-environment-conda-linux.yml
+++ b/2026.4/pathogenome/released/seed-environment-conda-linux.yml
@@ -1,3 +1,4 @@
+# trigger a new build
 channels:
 - https://packages.qiime2.org/qiime2/2026.4/pathogenome/released
 - conda-forge


### PR DESCRIPTION
triggering a rebuild to pull in changes from this commit: https://github.com/qiime2/action-library-packaging/commit/7b54ed14d6ed8a987c5a355ba14f6df4f7ff1650

this will remove the microarch virtual packages from the metapackage, thus preventing failed solves when installing via the channel/metapackage route (rather than using the solved environment file).