### PR TITLE
NEW: Adds `q2-mag` to the moshpit distro

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -94,6 +94,10 @@ packages:
   repo: qiime2/q2-longitudinal
   distros: [qiime2]
 
+- name: q2-mag
+  repo: bokulich-lab/q2-mag
+  distros: [moshpit]
+
 - name: q2-metadata
   repo: qiime2/q2-metadata
   distros: [tiny, qiime2, moshpit, pathogenome]


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
This PR adds the new [q2-mag](https://github.com/bokulich-lab/q2-mag) plugin to the MOSHPIT distro.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.
