### PR TITLE
PREP: 2026.10 dev bump (tiny/osx-64)

### DIFF
--- a/2026.10/tiny/passed/seed-environment-conda-osx.yml
+++ b/2026.10/tiny/passed/seed-environment-conda-osx.yml
@@ -1,0 +1,34 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.7/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+- biom-format=2.1.17
+- click=8.1.8
+- frictionless=5.5.0
+- h5py=3.15.1
+- hdf5=1.14.6
+- networkx=3.6.1
+- numpy=2.4.2
+- pandas=2.3.3
+- parsl=2026.2.23
+- python=3.12
+- q2-metadata=2026.7.0
+- q2-mystery-stew=2026.7.0
+- q2-types=2026.7.0
+- q2cli=2026.7.0
+- q2templates=2026.7.0
+- qiime2=2026.7.0
+- r-base=4.5.2
+- r-reticulate=1.45.0
+- rachis=2026.7.0
+- rnanorm=2.1.0
+- scikit-bio=0.7.2
+- scikit-learn=1.7.1
+- scipy=1.17.1
+- tzlocal=5.3.1
+- unifrac-binaries=1.5.1
+- unifrac=1.5.1
+extras:
+  variant_override:
+    qiime2_epoch: '2026.10'

--- a/2026.10/tiny/staged/seed-environment-conda-osx.yml
+++ b/2026.10/tiny/staged/seed-environment-conda-osx.yml
@@ -1,0 +1,36 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.7/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+- biom-format=2.1.17
+- click=8.1.8
+- decorator=4.4.2
+- frictionless=5.5.0
+- h5py=3.15.1
+- hdf5=1.14.6
+- networkx=3.6.1
+- notebook=6.5.5
+- numpy=2.4.2
+- pandas=2.3.3
+- parsl=2026.2.23
+- python=3.12
+- q2-metadata=2026.7.0
+- q2-mystery-stew=2026.7.0
+- q2-types=2026.7.0
+- q2cli=2026.7.0
+- q2templates=2026.7.0
+- qiime2=2026.7.0
+- r-base=4.5.2
+- r-reticulate=1.45.0
+- rachis=2026.7.0
+- rnanorm=2.1.0
+- scikit-bio=0.7.2
+- scikit-learn=1.7.1
+- scipy=1.17.1
+- tzlocal=5.3.1
+- unifrac-binaries=1.5.1
+- unifrac=1.5.1
+extras:
+  variant_override:
+    qiime2_epoch: '2026.10'


### PR DESCRIPTION
Automated dev bump for `tiny` osx-64 triggered by `bump-builds.yaml`.